### PR TITLE
#3 tsup use define global

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -162,9 +159,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -182,9 +176,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -202,9 +193,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1169,9 +1157,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1186,9 +1171,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1203,9 +1185,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1220,9 +1199,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1237,9 +1213,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1254,9 +1227,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,9 +1241,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1288,9 +1255,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1305,9 +1269,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,9 +1283,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1339,9 +1297,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1356,9 +1311,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1373,9 +1325,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "vitest": "^3.2.0"
   },
   "scripts": {
-    "prepare": "tsup src/index.ts --format esm,cjs --dts --external maplibre-gl",
-    "build": "tsup src/index.ts --format esm,cjs --dts --external maplibre-gl",
+    "prepare": "tsup",
+    "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",
     "dev": "vite --config vite.config.ts",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  external: ["maplibre-gl"],
+  define: {
+    global: "globalThis",
+  },
+});


### PR DESCRIPTION
Fixes #3

## Summary

<!-- Briefly describe your changes -->

tsupの設定に

```ts
  define: {
    global: "globalThis",
  },
```

を追加し、globalThisの参照をvite.config.tsに書かなくても良いようにした。

npm run buildのコマンドの修正を追加しているため、 #2 とブロックするのに注意。
  

## Checklist (optional)

- [ ] Tests added/updated
- [ ] Docs updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- ビルド設定をtsup.config.tsファイルに統合し、npm scriptsを簡潔化しました。設定の一元化により、ビルドプロセスの保守性が向上しています。ESMおよびCJS形式での出力、TypeScript定義ファイルの生成、外部依存関係の処理が適切に維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->