### PR TITLE
#20 MockMapの共有化 (test/helpers/mock-map.ts)

### DIFF
--- a/test/helpers/mock-map.ts
+++ b/test/helpers/mock-map.ts
@@ -1,0 +1,149 @@
+import { vi } from "vitest";
+
+type EventHandler = (...args: unknown[]) => void;
+
+/**
+ * Shared MockMap for unit testing without MapLibre GL dependency.
+ *
+ * Covers methods used across: simplestyle, simplestyle-vector, attribution, util.
+ */
+export class MockMap {
+  bounds = false;
+  layers: Record<string, unknown>[] = [];
+  sources: Record<string, unknown> = {};
+  removed = false;
+
+  private _eventHandlers: Map<string, EventHandler[]> = new Map();
+  private _layerEventHandlers: Map<string, EventHandler[]> = new Map();
+
+  addSource(id: string, source: unknown) {
+    this.sources[id] = source;
+  }
+
+  addLayer(layer: Record<string, unknown>) {
+    this.layers.push(layer);
+  }
+
+  getSource(id: string) {
+    const sources = this.sources;
+    const raw = sources[id] as Record<string, unknown> | undefined;
+    return raw
+      ? {
+          ...raw,
+          setData(geojson: unknown) {
+            sources[id] = { type: "geojson", data: geojson };
+          },
+        }
+      : undefined;
+  }
+
+  getLayer(id: string) {
+    return this.layers.find((l) => l.id === id);
+  }
+
+  removeLayer(id: string) {
+    this.layers = this.layers.filter((l) => l.id !== id);
+  }
+
+  removeSource(id: string) {
+    delete this.sources[id];
+  }
+
+  on(eventOrLayer: string, handlerOrLayer?: EventHandler | string, handler?: EventHandler) {
+    if (typeof handlerOrLayer === "function") {
+      // on(event, handler)
+      const handlers = this._eventHandlers.get(eventOrLayer) || [];
+      handlers.push(handlerOrLayer);
+      this._eventHandlers.set(eventOrLayer, handlers);
+    } else if (typeof handlerOrLayer === "string" && typeof handler === "function") {
+      // on(event, layer, handler)
+      const key = `${eventOrLayer}:${handlerOrLayer}`;
+      const handlers = this._layerEventHandlers.get(key) || [];
+      handlers.push(handler);
+      this._layerEventHandlers.set(key, handlers);
+    }
+  }
+
+  off(eventOrLayer: string, handlerOrLayer?: EventHandler | string, handler?: EventHandler) {
+    if (typeof handlerOrLayer === "function") {
+      // off(event, handler)
+      const handlers = this._eventHandlers.get(eventOrLayer) || [];
+      this._eventHandlers.set(
+        eventOrLayer,
+        handlers.filter((h) => h !== handlerOrLayer),
+      );
+    } else if (typeof handlerOrLayer === "string" && typeof handler === "function") {
+      // off(event, layer, handler)
+      const key = `${eventOrLayer}:${handlerOrLayer}`;
+      const handlers = this._layerEventHandlers.get(key) || [];
+      this._layerEventHandlers.set(
+        key,
+        handlers.filter((h) => h !== handler),
+      );
+    }
+  }
+
+  getCanvas() {
+    return { style: { cursor: "" } };
+  }
+
+  getContainer() {
+    return { dataset: {} } as unknown as HTMLElement;
+  }
+
+  getCanvasContainer() {
+    return { offsetWidth: 800 } as unknown as HTMLElement;
+  }
+
+  fitBounds(..._args: unknown[]) {
+    this.bounds = true;
+  }
+
+  queryRenderedFeatures(_point: unknown, _options?: unknown) {
+    return [] as unknown[];
+  }
+
+  easeTo(_options: unknown) {}
+
+  remove() {
+    this.removed = true;
+  }
+
+  /** Fire registered event handlers (useful for testing event-driven behavior). */
+  fire(event: string, data?: unknown) {
+    const handlers = this._eventHandlers.get(event) || [];
+    for (const handler of handlers) {
+      handler(data);
+    }
+  }
+
+  /** Fire registered layer-scoped event handlers. */
+  fireLayerEvent(event: string, layer: string, data?: unknown) {
+    const key = `${event}:${layer}`;
+    const handlers = this._layerEventHandlers.get(key) || [];
+    for (const handler of handlers) {
+      handler(data);
+    }
+  }
+}
+
+/** Create a MockMap instance with all methods spied via vi.spyOn. */
+export function createMockMap(): MockMap {
+  const map = new MockMap();
+  vi.spyOn(map, "addSource");
+  vi.spyOn(map, "addLayer");
+  vi.spyOn(map, "getSource");
+  vi.spyOn(map, "getLayer");
+  vi.spyOn(map, "removeLayer");
+  vi.spyOn(map, "removeSource");
+  vi.spyOn(map, "on");
+  vi.spyOn(map, "off");
+  vi.spyOn(map, "getCanvas");
+  vi.spyOn(map, "getContainer");
+  vi.spyOn(map, "getCanvasContainer");
+  vi.spyOn(map, "fitBounds");
+  vi.spyOn(map, "queryRenderedFeatures");
+  vi.spyOn(map, "easeTo");
+  vi.spyOn(map, "remove");
+  return map;
+}

--- a/test/helpers/mock-map.ts
+++ b/test/helpers/mock-map.ts
@@ -49,13 +49,20 @@ export class MockMap {
     delete this.sources[id];
   }
 
-  on(eventOrLayer: string, handlerOrLayer?: EventHandler | string, handler?: EventHandler) {
+  on(
+    eventOrLayer: string,
+    handlerOrLayer?: EventHandler | string,
+    handler?: EventHandler,
+  ) {
     if (typeof handlerOrLayer === "function") {
       // on(event, handler)
       const handlers = this._eventHandlers.get(eventOrLayer) || [];
       handlers.push(handlerOrLayer);
       this._eventHandlers.set(eventOrLayer, handlers);
-    } else if (typeof handlerOrLayer === "string" && typeof handler === "function") {
+    } else if (
+      typeof handlerOrLayer === "string" &&
+      typeof handler === "function"
+    ) {
       // on(event, layer, handler)
       const key = `${eventOrLayer}:${handlerOrLayer}`;
       const handlers = this._layerEventHandlers.get(key) || [];
@@ -64,7 +71,11 @@ export class MockMap {
     }
   }
 
-  off(eventOrLayer: string, handlerOrLayer?: EventHandler | string, handler?: EventHandler) {
+  off(
+    eventOrLayer: string,
+    handlerOrLayer?: EventHandler | string,
+    handler?: EventHandler,
+  ) {
     if (typeof handlerOrLayer === "function") {
       // off(event, handler)
       const handlers = this._eventHandlers.get(eventOrLayer) || [];
@@ -72,7 +83,10 @@ export class MockMap {
         eventOrLayer,
         handlers.filter((h) => h !== handlerOrLayer),
       );
-    } else if (typeof handlerOrLayer === "string" && typeof handler === "function") {
+    } else if (
+      typeof handlerOrLayer === "string" &&
+      typeof handler === "function"
+    ) {
       // off(event, layer, handler)
       const key = `${eventOrLayer}:${handlerOrLayer}`;
       const handlers = this._layerEventHandlers.get(key) || [];

--- a/test/helpers/mock-map.ts
+++ b/test/helpers/mock-map.ts
@@ -12,6 +12,9 @@ export class MockMap {
   layers: Record<string, unknown>[] = [];
   sources: Record<string, unknown> = {};
   removed = false;
+  private _canvas = { style: { cursor: "" } };
+  private _container = { dataset: {} } as unknown as HTMLElement;
+  private _canvasContainer = { offsetWidth: 800 } as unknown as HTMLElement;
 
   private _eventHandlers: Map<string, EventHandler[]> = new Map();
   private _layerEventHandlers: Map<string, EventHandler[]> = new Map();
@@ -25,16 +28,19 @@ export class MockMap {
   }
 
   getSource(id: string) {
-    const sources = this.sources;
-    const raw = sources[id] as Record<string, unknown> | undefined;
-    return raw
-      ? {
-          ...raw,
-          setData(geojson: unknown) {
-            sources[id] = { type: "geojson", data: geojson };
-          },
-        }
-      : undefined;
+    const raw = this.sources[id] as
+      | (Record<string, unknown> & {
+          data?: unknown;
+          setData?: (geojson: unknown) => void;
+        })
+      | undefined;
+    if (!raw) return undefined;
+
+    raw.setData ??= (geojson: unknown) => {
+      raw.data = geojson;
+    };
+
+    return raw;
   }
 
   getLayer(id: string) {
@@ -98,15 +104,15 @@ export class MockMap {
   }
 
   getCanvas() {
-    return { style: { cursor: "" } };
+    return this._canvas;
   }
 
   getContainer() {
-    return { dataset: {} } as unknown as HTMLElement;
+    return this._container;
   }
 
   getCanvasContainer() {
-    return { offsetWidth: 800 } as unknown as HTMLElement;
+    return this._canvasContainer;
   }
 
   fitBounds(..._args: unknown[]) {

--- a/test/simplestyle.test.ts
+++ b/test/simplestyle.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { MockMap } from "./helpers/mock-map";
 
 beforeAll(() => {
   // maplibre-gl tries URL.createObjectURL on import
@@ -9,44 +10,6 @@ beforeAll(() => {
     window.URL.createObjectURL = () => "blob:mock";
   }
 });
-
-// Mock Map class for testing SimpleStyle without MapLibre
-class MockMap {
-  bounds = false;
-  layers: Record<string, unknown>[] = [];
-  sources: Record<string, unknown> = {};
-
-  addSource(id: string, source: unknown) {
-    this.sources[id] = source;
-  }
-
-  addLayer(layer: Record<string, unknown>) {
-    this.layers.push(layer);
-  }
-
-  on() {}
-
-  getSource(id: string) {
-    const sources = this.sources;
-    return {
-      setData(geojson: unknown) {
-        sources[id] = { type: "geojson", data: geojson };
-      },
-    };
-  }
-
-  getCanvas() {
-    return { style: {} };
-  }
-
-  getContainer() {
-    return { dataset: {} };
-  }
-
-  fitBounds() {
-    this.bounds = true;
-  }
-}
 
 const geojson = {
   type: "FeatureCollection",


### PR DESCRIPTION
## Summary
- `test/helpers/mock-map.ts` に共有 `MockMap` クラスと `createMockMap()` ファクトリを新規作成
- `simplestyle.test.ts` のインライン MockMap を共有ヘルパーに置き換え
- 今後のテスト拡充 (#21〜#28) で必要になるメソッドを追加: `getLayer`, `removeLayer`, `removeSource`, `off`, `getCanvasContainer`, `queryRenderedFeatures`, `easeTo`, `remove`, イベント発火ヘルパー

## Test plan
- [x] 全79テストがパスすることを確認済み (`npx vitest run`)

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * テスト用のモックマップヘルパーを追加し、テストインフラを拡張しました。
  * 既存のテストを新しいヘルパーに切り替え、テスト実装を簡潔化して再利用性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->