### PR TITLE
#30 fix TypeError in SimpleStyle.updateData on fetch failure

### DIFF
--- a/src/lib/simplestyle.ts
+++ b/src/lib/simplestyle.ts
@@ -431,7 +431,7 @@ export class SimpleStyle {
       const fetchGeoJSON = async () => {
         try {
           const response = await window.fetch(geojson);
-          const data = response.ok ? await response.json() : {};
+          const data = response.ok ? await response.json() : template;
           this.geojson = data;
           this.updateData(data);
 


### PR DESCRIPTION
Fixes #30

## Summary
- `setGeoJSON` の fetch 失敗時に `data = {}` をそのまま `updateData` に渡していたため、`this.geojson.features` が undefined となり `.filter()` で `TypeError` が発生していた（外側の `catch` で握り潰されて stderr に出るのみ）
- 空の FeatureCollection を表す `template` をフォールバックに使うように変更

## Test plan
- [x] `npm run test` が通る（`simplestyle.test.ts` の stderr 出力も消えている）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ネットワークエラー発生時のGeoJSONデータ処理を改善しました。エラー時により安定した形式のデータが返されるようになり、ダウンストリーム処理の信頼性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->