### PR TITLE
#22 SimpleStyleVector のユニットテスト新規作成

### DIFF
--- a/test/simplestyle-vector.test.ts
+++ b/test/simplestyle-vector.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockMap } from "./helpers/mock-map";
+
+// Mock maplibre-gl Popup used in setPopup()
+vi.mock("maplibre-gl", () => {
+  class MockPopup {
+    setLngLat() {
+      return this;
+    }
+    setHTML() {
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+  }
+  return { default: { Popup: MockPopup } };
+});
+
+beforeAll(() => {
+  if (!window.URL.createObjectURL) {
+    window.URL.createObjectURL = () => "blob:mock";
+  }
+});
+
+const TEST_URL = "https://example.com/tiles/{z}/{x}/{y}.pbf";
+
+const EXPECTED_LAYER_IDS = [
+  "vt-geolonia-simple-style-polygon",
+  "vt-geolonia-simple-style-linestring",
+  "vt-geolonia-simple-style-polygon-symbol",
+  "vt-geolonia-simple-style-linestring-symbol",
+  "vt-circle-simple-style-points",
+  "vt-geolonia-simple-style-points",
+];
+
+describe("SimpleStyleVector", () => {
+  let SimpleStyleVector: typeof import("../src/lib/simplestyle-vector").default;
+  let map: MockMap;
+
+  beforeAll(async () => {
+    const mod = await import("../src/lib/simplestyle-vector");
+    SimpleStyleVector = mod.default;
+  });
+
+  beforeEach(() => {
+    map = new MockMap();
+  });
+
+  it("should add 1 source and 6 layers", () => {
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    expect(Object.keys(map.sources)).toHaveLength(1);
+    expect(map.layers).toHaveLength(6);
+  });
+
+  it("should add source with type 'vector' and correct url", () => {
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    const source = map.sources["vt-geolonia-simple-style"] as Record<
+      string,
+      unknown
+    >;
+    expect(source.type).toBe("vector");
+    expect(source.url).toBe(TEST_URL);
+  });
+
+  it("should use 'vt-geolonia-simple-style' as source name", () => {
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    expect(map.sources).toHaveProperty("vt-geolonia-simple-style");
+  });
+
+  it("should create layers for each geometry type", () => {
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    const layerIds = map.layers.map((l) => l.id);
+    for (const id of EXPECTED_LAYER_IDS) {
+      expect(layerIds).toContain(id);
+    }
+  });
+
+  it("should register click/mouseenter/mouseleave events for 4 popup layers", () => {
+    const onSpy = vi.spyOn(map, "on");
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    const popupLayers = [
+      "vt-geolonia-simple-style-polygon",
+      "vt-geolonia-simple-style-linestring",
+      "vt-circle-simple-style-points",
+      "vt-geolonia-simple-style-points",
+    ];
+
+    for (const layer of popupLayers) {
+      for (const event of ["click", "mouseenter", "mouseleave"]) {
+        expect(
+          onSpy.mock.calls.some(
+            (call) => call[0] === event && call[1] === layer,
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("should change cursor on mouseenter/mouseleave", () => {
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    const layer = "vt-geolonia-simple-style-polygon";
+
+    // mouseenter with description sets pointer cursor
+    map.fireLayerEvent("mouseenter", layer, {
+      features: [{ properties: { description: "hello" } }],
+    });
+    expect(map.getCanvas().style.cursor).toBe("pointer");
+
+    // mouseleave resets cursor
+    map.fireLayerEvent("mouseleave", layer, {});
+    expect(map.getCanvas().style.cursor).toBe("");
+  });
+
+  it("should register sourcedata listener for fitBounds when dataset.lng is not set", () => {
+    const onSpy = vi.spyOn(map, "on");
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    const sourcedataCalls = onSpy.mock.calls.filter(
+      (call) => call[0] === "sourcedata" && typeof call[1] === "function",
+    );
+    expect(sourcedataCalls).toHaveLength(1);
+  });
+
+  it("should skip fitBounds listener when dataset.lng is set", () => {
+    (
+      map.getContainer() as unknown as { dataset: Record<string, string> }
+    ).dataset.lng = "139.77";
+    (
+      map.getContainer() as unknown as { dataset: Record<string, string> }
+    ).dataset.lat = "35.68";
+
+    const onSpy = vi.spyOn(map, "on");
+    new SimpleStyleVector(TEST_URL).addTo(map);
+
+    const sourcedataCalls = onSpy.mock.calls.filter(
+      (call) => call[0] === "sourcedata" && typeof call[1] === "function",
+    );
+    expect(sourcedataCalls).toHaveLength(0);
+  });
+});

--- a/test/simplestyle-vector.test.ts
+++ b/test/simplestyle-vector.test.ts
@@ -1,7 +1,15 @@
 /**
  * @vitest-environment jsdom
  */
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { MockMap } from "./helpers/mock-map";
 
 // Mock maplibre-gl Popup used in setPopup()
@@ -20,10 +28,16 @@ vi.mock("maplibre-gl", () => {
   return { default: { Popup: MockPopup } };
 });
 
+const originalCreateObjectURL = window.URL.createObjectURL;
+
 beforeAll(() => {
   if (!window.URL.createObjectURL) {
     window.URL.createObjectURL = () => "blob:mock";
   }
+});
+
+afterAll(() => {
+  window.URL.createObjectURL = originalCreateObjectURL;
 });
 
 const TEST_URL = "https://example.com/tiles/{z}/{x}/{y}.pbf";
@@ -132,12 +146,9 @@ describe("SimpleStyleVector", () => {
   });
 
   it("should skip fitBounds listener when dataset.lng is set", () => {
-    (
-      map.getContainer() as unknown as { dataset: Record<string, string> }
-    ).dataset.lng = "139.77";
-    (
-      map.getContainer() as unknown as { dataset: Record<string, string> }
-    ).dataset.lat = "35.68";
+    const container = map.getContainer() as { dataset: Record<string, string> };
+    container.dataset.lng = "139.77";
+    container.dataset.lat = "35.68";
 
     const onSpy = vi.spyOn(map, "on");
     new SimpleStyleVector(TEST_URL).addTo(map);


### PR DESCRIPTION
## Summary
- `test/simplestyle-vector.test.ts` を新規作成（8テストケース）
- `maplibre-gl` の `Popup` を `vi.mock()` でモック化、`MockMap` 共有ヘルパーを利用
- テストケース:
  - ソース・レイヤー生成数（1ソース + 6レイヤー）
  - ソース type/url 検証
  - ソース名（vt-geolonia-simple-style）
  - ジオメトリ別レイヤーID存在確認
  - ポップアップイベント登録（click/mouseenter/mouseleave × 4レイヤー）
  - マウスカーソル変更動作
  - 自動fitBounds（dataset.lng未設定時）
  - fitBounds制御（dataset.lng設定時スキップ）
- Coverage: `simplestyle-vector.ts` Statements 66.66%, Functions 80%

## Test plan
- [x] 全87テストがパスすることを確認済み (`npx vitest run`)
- [x] `npx biome check` でlintエラーなし

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト
* SimpleStyleVector モジュールの包括的な検証テストスイートを追加。ベクターソース、レイヤー管理、ポップアップハンドラー、カーソルインタラクションなど主要機能の動作確認テストを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->