### PR TITLE
#34 improve E2E test environment

### DIFF
--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -106,24 +106,28 @@ export async function waitForMapLoadOn(
 
 /**
  * Intercept network requests matching a URL pattern and collect them.
- * Call this BEFORE navigating to the page.
+ * Call this BEFORE navigating to the page. Call `dispose()` when done
+ * to remove the listener.
  */
 export function interceptRequests(
   page: Page,
   urlPattern: string | RegExp,
-): Request[] {
+): { requests: Request[]; dispose: () => void } {
   const requests: Request[] = [];
-  page.on("request", (req) => {
+  const pattern =
+    typeof urlPattern === "string"
+      ? urlPattern
+      : new RegExp(urlPattern.source, urlPattern.flags.replace(/[gy]/g, ""));
+  const onRequest = (req: Request) => {
     const url = req.url();
     if (
-      typeof urlPattern === "string"
-        ? url.includes(urlPattern)
-        : urlPattern.test(url)
+      typeof pattern === "string" ? url.includes(pattern) : pattern.test(url)
     ) {
       requests.push(req);
     }
-  });
-  return requests;
+  };
+  page.on("request", onRequest);
+  return { requests, dispose: () => page.off("request", onRequest) };
 }
 
 /**

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Page, Request } from "@playwright/test";
 
 const LOAD_TIMEOUT = 15000;
 
@@ -79,4 +79,84 @@ export function collectConsoleErrors(page: Page): string[] {
   });
   page.on("pageerror", (err) => errors.push(err.message));
   return errors;
+}
+
+/**
+ * Wait for a specific map container to load (for pages with multiple maps).
+ */
+export async function waitForMapLoadOn(
+  page: Page,
+  containerSelector: string,
+): Promise<void> {
+  await page.waitForSelector(`${containerSelector} canvas.maplibregl-canvas`, {
+    timeout: LOAD_TIMEOUT,
+  });
+  await page.waitForFunction(
+    (selector: string) => {
+      const container = document.querySelector(selector) as
+        | (HTMLElement & { geoloniaMap?: { loaded?: () => boolean } })
+        | null;
+      const map = container?.geoloniaMap;
+      return map && typeof map.loaded === "function" && map.loaded();
+    },
+    containerSelector,
+    { timeout: LOAD_TIMEOUT },
+  );
+}
+
+/**
+ * Intercept network requests matching a URL pattern and collect them.
+ * Call this BEFORE navigating to the page.
+ */
+export function interceptRequests(
+  page: Page,
+  urlPattern: string | RegExp,
+): Request[] {
+  const requests: Request[] = [];
+  page.on("request", (req) => {
+    const url = req.url();
+    if (
+      typeof urlPattern === "string"
+        ? url.includes(urlPattern)
+        : urlPattern.test(url)
+    ) {
+      requests.push(req);
+    }
+  });
+  return requests;
+}
+
+/**
+ * Check if a map layer exists.
+ */
+export async function hasLayer(page: Page, layerId: string): Promise<boolean> {
+  return page.evaluate((id: string) => {
+    const map = (window as unknown as Record<string, unknown>).map as
+      | { getLayer?: (id: string) => unknown }
+      | undefined;
+    return !!map?.getLayer?.(id);
+  }, layerId);
+}
+
+/**
+ * Check if a map source exists.
+ */
+export async function hasSource(
+  page: Page,
+  sourceId: string,
+): Promise<boolean> {
+  return page.evaluate((id: string) => {
+    const map = (window as unknown as Record<string, unknown>).map as
+      | { getSource?: (id: string) => unknown }
+      | undefined;
+    return !!map?.getSource?.(id);
+  }, sourceId);
+}
+
+/**
+ * Check if a popup is currently visible on the page.
+ */
+export async function isPopupVisible(page: Page): Promise<boolean> {
+  const popup = page.locator(".maplibregl-popup");
+  return popup.isVisible();
 }

--- a/example/controls.html
+++ b/example/controls.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Controls E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/controls.ts"></script>
+</body>
+</html>

--- a/example/controls.ts
+++ b/example/controls.ts
@@ -1,0 +1,35 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import type { ControlPosition } from "maplibre-gl";
+import { GeoloniaMap } from "../src/index";
+
+// Read control options from URL search params
+const params = new URLSearchParams(window.location.search);
+
+function parseBoolOrPosition(
+  value: string | null,
+): boolean | ControlPosition | undefined {
+  if (value === null) return undefined;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return value as ControlPosition;
+}
+
+const map = new GeoloniaMap({
+  container: "#map",
+  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  center: [139.7671, 35.6812],
+  zoom: 12,
+  gestureHandling: false,
+  loader: false,
+  navigationControl:
+    parseBoolOrPosition(params.get("navigationControl")) ?? true,
+  fullscreenControl:
+    parseBoolOrPosition(params.get("fullscreenControl")) ?? false,
+  scaleControl: parseBoolOrPosition(params.get("scaleControl")) ?? false,
+  geolocateControl:
+    parseBoolOrPosition(params.get("geolocateControl")) ?? false,
+  geoloniaControl: parseBoolOrPosition(params.get("geoloniaControl")) ?? true,
+});
+
+(window as unknown as Record<string, unknown>).map = map;

--- a/example/options.html
+++ b/example/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Options E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/options.ts"></script>
+</body>
+</html>

--- a/example/options.ts
+++ b/example/options.ts
@@ -1,0 +1,29 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import { GeoloniaMap } from "../src/index";
+
+// Read options from URL search params so e2e tests can configure dynamically
+const params = new URLSearchParams(window.location.search);
+
+const map = new GeoloniaMap({
+  container: "#map",
+  style:
+    params.get("style") ||
+    "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  center: params.has("center")
+    ? JSON.parse(params.get("center")!)
+    : [139.7671, 35.6812],
+  zoom: params.has("zoom") ? Number(params.get("zoom")) : 12,
+  minZoom: params.has("minZoom") ? Number(params.get("minZoom")) : undefined,
+  maxZoom: params.has("maxZoom") ? Number(params.get("maxZoom")) : undefined,
+  bearing: params.has("bearing") ? Number(params.get("bearing")) : undefined,
+  pitch: params.has("pitch") ? Number(params.get("pitch")) : undefined,
+  hash: params.get("hash") === "true",
+  lang: (params.get("lang") as "ja" | "en" | "auto") || undefined,
+  navigationControl: false,
+  geoloniaControl: false,
+  gestureHandling: false,
+  loader: false,
+});
+
+(window as unknown as Record<string, unknown>).map = map;


### PR DESCRIPTION
Fixes #34

## Summary
- `e2e/helper.ts` に5つのヘルパー関数を追加（`waitForMapLoadOn`, `interceptRequests`, `hasLayer`, `hasSource`, `isPopupVisible`）
- Phase 1 用テストページ `example/options.html+ts`, `example/controls.html+ts` を新規作成（URLパラメータで動的にオプション指定可能）

## Test plan
- [x] `npm run test` パス（ユニットテスト 93件）
- [x] `npm run lint` エラーなし
- [x] `npm run e2e` で既存E2Eテストが壊れていないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * マップコントロール機能の使用方法を示す新しいサンプルページを追加しました。
  * URLパラメータを使用してマップオプションを動的に設定できるサンプルページを追加しました。

* **テスト**
  * エンドツーエンドテストの補助機能を拡張し、マップの読み込み待機、レイヤーおよびソース確認機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->