### PR TITLE
#23 CustomAttributionControl のユニットテスト新規作成

### DIFF
--- a/test/attribution.test.ts
+++ b/test/attribution.test.ts
@@ -17,22 +17,22 @@ beforeAll(() => {
     window.URL.createObjectURL = () => "blob:mock";
   }
   // jsdom does not implement matchMedia
-  if (!window.matchMedia) {
-    window.matchMedia = () =>
-      ({
-        matches: false,
-        media: "",
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      }) as unknown as MediaQueryList;
-  }
-});
-
-afterAll(() => {
-  window.URL.createObjectURL = originalCreateObjectURL;
+  window.matchMedia = () =>
+    ({
+      matches: false,
+      media: "",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as unknown as MediaQueryList;
 });
 
 const originalCreateObjectURL = window.URL.createObjectURL;
+const originalMatchMedia = window.matchMedia;
+
+afterAll(() => {
+  window.URL.createObjectURL = originalCreateObjectURL;
+  window.matchMedia = originalMatchMedia;
+});
 
 /**
  * Extend MockMap with internal properties required by CustomAttributionControl.
@@ -170,6 +170,27 @@ describe("CustomAttributionControl", () => {
       ctrl.onRemove();
       expect(document.body.contains(container)).toBe(false);
     });
+
+    it("should unregister print media query listener", () => {
+      const removeListenerSpy = vi.fn();
+      window.matchMedia = () =>
+        ({
+          matches: false,
+          media: "",
+          addEventListener: vi.fn(),
+          removeEventListener: removeListenerSpy,
+        }) as unknown as MediaQueryList;
+
+      const m = createAttributionMap();
+      const c = new CustomAttributionControl();
+      c.onAdd(m as never);
+      c.onRemove();
+
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+    });
   });
 
   describe("_updateAttributions", () => {
@@ -273,6 +294,17 @@ describe("CustomAttributionControl", () => {
   describe("_updateCompact", () => {
     it("should add compact classes when canvas width ≤ 640", () => {
       const map = createAttributionMap({ canvasWidth: 400 });
+      const ctrl = new CustomAttributionControl({
+        customAttribution: "© Test",
+      });
+      const container = ctrl.onAdd(map as never);
+      const details = container.shadowRoot?.querySelector("details");
+
+      expect(details?.classList.contains("maplibregl-compact")).toBe(true);
+    });
+
+    it("should add compact classes when canvas width = 640", () => {
+      const map = createAttributionMap({ canvasWidth: 640 });
       const ctrl = new CustomAttributionControl({
         customAttribution: "© Test",
       });

--- a/test/attribution.test.ts
+++ b/test/attribution.test.ts
@@ -1,0 +1,316 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { MockMap } from "./helpers/mock-map";
+
+beforeAll(() => {
+  if (!window.URL.createObjectURL) {
+    window.URL.createObjectURL = () => "blob:mock";
+  }
+  // jsdom does not implement matchMedia
+  if (!window.matchMedia) {
+    window.matchMedia = () =>
+      ({
+        matches: false,
+        media: "",
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList;
+  }
+});
+
+afterAll(() => {
+  window.URL.createObjectURL = originalCreateObjectURL;
+});
+
+const originalCreateObjectURL = window.URL.createObjectURL;
+
+/**
+ * Extend MockMap with internal properties required by CustomAttributionControl.
+ */
+function createAttributionMap(
+  opts: {
+    canvasWidth?: number;
+    sourceCaches?: Record<
+      string,
+      { used: boolean; usedForTerrain: boolean; attribution?: string }
+    >;
+  } = {},
+) {
+  const map = new MockMap();
+
+  // Set canvas container width for compact detection
+  Object.defineProperty(map.getCanvasContainer(), "offsetWidth", {
+    value: opts.canvasWidth ?? 800,
+    writable: true,
+  });
+
+  // Internal _getUIString used by _setElementTitle
+  (map as unknown as Record<string, unknown>)._getUIString = (key: string) =>
+    `ui:${key}`;
+
+  // Internal style property with sourceCaches
+  const caches: Record<string, unknown> = {};
+  for (const [id, sc] of Object.entries(opts.sourceCaches ?? {})) {
+    caches[id] = {
+      used: sc.used,
+      usedForTerrain: sc.usedForTerrain,
+      getSource: () => ({ attribution: sc.attribution }),
+    };
+  }
+  (map as unknown as Record<string, unknown>).style = {
+    sourceCaches: caches,
+  };
+
+  return map;
+}
+
+describe("CustomAttributionControl", () => {
+  let CustomAttributionControl: typeof import("../src/lib/controls/attribution").default;
+
+  beforeAll(async () => {
+    const mod = await import("../src/lib/controls/attribution");
+    CustomAttributionControl = mod.default;
+  });
+
+  describe("getDefaultPosition", () => {
+    it('should return "bottom-right"', () => {
+      const ctrl = new CustomAttributionControl();
+      expect(ctrl.getDefaultPosition()).toBe("bottom-right");
+    });
+  });
+
+  describe("onAdd", () => {
+    let map: MockMap;
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+      map = createAttributionMap();
+      const ctrl = new CustomAttributionControl();
+      container = ctrl.onAdd(map as never);
+    });
+
+    it("should create a Shadow DOM", () => {
+      expect(container.shadowRoot).not.toBeNull();
+    });
+
+    it("should have details + summary + div inside shadow", () => {
+      const shadow = container.shadowRoot;
+      expect(shadow).not.toBeNull();
+      const details = shadow?.querySelector("details");
+      expect(details).not.toBeNull();
+
+      const summary = details?.querySelector("summary");
+      expect(summary).not.toBeNull();
+      expect(summary?.classList.contains("maplibregl-ctrl-attrib-button")).toBe(
+        true,
+      );
+
+      const inner = details?.querySelector("div.maplibregl-ctrl-attrib-inner");
+      expect(inner).not.toBeNull();
+    });
+
+    it("should register map events (styledata, sourcedata, terrain, resize, drag)", () => {
+      const onSpy = vi.spyOn(map, "on");
+      const ctrl = new CustomAttributionControl();
+      ctrl.onAdd(map as never);
+
+      const registeredEvents = onSpy.mock.calls.map((call) => call[0]);
+      for (const event of [
+        "styledata",
+        "sourcedata",
+        "terrain",
+        "resize",
+        "drag",
+      ]) {
+        expect(registeredEvents).toContain(event);
+      }
+    });
+  });
+
+  describe("onRemove", () => {
+    let map: MockMap;
+    let ctrl: InstanceType<typeof CustomAttributionControl>;
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+      map = createAttributionMap();
+      ctrl = new CustomAttributionControl();
+      container = ctrl.onAdd(map as never);
+      // Attach to DOM so DOM.remove can work
+      document.body.appendChild(container);
+    });
+
+    it("should unregister all map events", () => {
+      const offSpy = vi.spyOn(map, "off");
+      ctrl.onRemove();
+
+      const unregisteredEvents = offSpy.mock.calls.map((call) => call[0]);
+      for (const event of [
+        "styledata",
+        "sourcedata",
+        "terrain",
+        "resize",
+        "drag",
+      ]) {
+        expect(unregisteredEvents).toContain(event);
+      }
+    });
+
+    it("should remove the container from DOM", () => {
+      ctrl.onRemove();
+      expect(document.body.contains(container)).toBe(false);
+    });
+  });
+
+  describe("_updateAttributions", () => {
+    it("should display custom attribution string", () => {
+      const map = createAttributionMap();
+      const ctrl = new CustomAttributionControl({
+        customAttribution: "© Custom",
+      });
+      const container = ctrl.onAdd(map as never);
+      const inner = container.shadowRoot?.querySelector(
+        ".maplibregl-ctrl-attrib-inner",
+      );
+      expect(inner?.innerHTML).toBe("© Custom");
+    });
+
+    it('should join attribution array with " | "', () => {
+      const map = createAttributionMap();
+      const ctrl = new CustomAttributionControl({
+        customAttribution: ["© A", "© B"],
+      });
+      const container = ctrl.onAdd(map as never);
+      const inner = container.shadowRoot?.querySelector(
+        ".maplibregl-ctrl-attrib-inner",
+      );
+      expect(inner?.innerHTML).toBe("© A | © B");
+    });
+
+    it("should deduplicate attributions", () => {
+      const map = createAttributionMap();
+      const ctrl = new CustomAttributionControl({
+        customAttribution: ["© A", "© A"],
+      });
+      const container = ctrl.onAdd(map as never);
+      const inner = container.shadowRoot?.querySelector(
+        ".maplibregl-ctrl-attrib-inner",
+      );
+      // After dedup, only one "© A" should remain
+      expect(inner?.innerHTML).toBe("© A");
+    });
+
+    it("should collect attributions from source caches", () => {
+      const map = createAttributionMap({
+        sourceCaches: {
+          src1: { used: true, usedForTerrain: false, attribution: "© Source1" },
+          src2: {
+            used: false,
+            usedForTerrain: true,
+            attribution: "© Source2",
+          },
+          src3: {
+            used: false,
+            usedForTerrain: false,
+            attribution: "© Unused",
+          },
+        },
+      });
+      const ctrl = new CustomAttributionControl();
+      const container = ctrl.onAdd(map as never);
+      const inner = container.shadowRoot?.querySelector(
+        ".maplibregl-ctrl-attrib-inner",
+      );
+      expect(inner?.innerHTML).toContain("© Source1");
+      expect(inner?.innerHTML).toContain("© Source2");
+      expect(inner?.innerHTML).not.toContain("© Unused");
+    });
+
+    it("should add maplibregl-attrib-empty class when no attributions", () => {
+      const map = createAttributionMap();
+      const ctrl = new CustomAttributionControl();
+      const container = ctrl.onAdd(map as never);
+      const details = container.shadowRoot?.querySelector("details");
+      expect(details?.classList.contains("maplibregl-attrib-empty")).toBe(true);
+    });
+  });
+
+  describe("_toggleAttribution", () => {
+    it("should toggle compact-show class", () => {
+      const map = createAttributionMap({ canvasWidth: 400 });
+      const ctrl = new CustomAttributionControl({
+        customAttribution: "© Test",
+      });
+      const container = ctrl.onAdd(map as never);
+      const details = container.shadowRoot?.querySelector("details");
+
+      // Initially compact + compact-show after onAdd with small canvas
+      expect(details?.classList.contains("maplibregl-compact")).toBe(true);
+      expect(details?.classList.contains("maplibregl-compact-show")).toBe(true);
+
+      // First toggle: removes compact-show
+      ctrl._toggleAttribution();
+      expect(details?.classList.contains("maplibregl-compact-show")).toBe(
+        false,
+      );
+
+      // Second toggle: adds compact-show back
+      ctrl._toggleAttribution();
+      expect(details?.classList.contains("maplibregl-compact-show")).toBe(true);
+    });
+  });
+
+  describe("_updateCompact", () => {
+    it("should add compact classes when canvas width ≤ 640", () => {
+      const map = createAttributionMap({ canvasWidth: 400 });
+      const ctrl = new CustomAttributionControl({
+        customAttribution: "© Test",
+      });
+      const container = ctrl.onAdd(map as never);
+      const details = container.shadowRoot?.querySelector("details");
+
+      expect(details?.classList.contains("maplibregl-compact")).toBe(true);
+    });
+
+    it("should not add compact classes when canvas width > 640", () => {
+      const map = createAttributionMap({ canvasWidth: 800 });
+      const ctrl = new CustomAttributionControl({
+        customAttribution: "© Test",
+      });
+      const container = ctrl.onAdd(map as never);
+      const details = container.shadowRoot?.querySelector("details");
+
+      expect(details?.classList.contains("maplibregl-compact")).toBe(false);
+    });
+  });
+
+  describe("_updateCompactMinimize", () => {
+    it("should remove compact-show on drag", () => {
+      const map = createAttributionMap({ canvasWidth: 400 });
+      const ctrl = new CustomAttributionControl({
+        customAttribution: "© Test",
+      });
+      const container = ctrl.onAdd(map as never);
+      const details = container.shadowRoot?.querySelector("details");
+
+      // Initially compact-show is set
+      expect(details?.classList.contains("maplibregl-compact-show")).toBe(true);
+
+      // Simulate drag event
+      map.fire("drag");
+      expect(details?.classList.contains("maplibregl-compact-show")).toBe(
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `test/attribution.test.ts` を新規作成（15テストケース）
- `MockMap` を拡張し、`_getUIString`・`style.sourceCaches` など内部APIをモック
- `window.matchMedia` のjsdom用ポリフィルを追加
- テストケース:
  - getDefaultPosition() が "bottom-right" を返却
  - Shadow DOM 生成確認
  - 内部構造（details + summary + div）確認
  - map イベント登録（styledata, sourcedata, terrain, resize, drag）
  - onRemove() でのイベント解除
  - DOM 削除確認
  - カスタム属性文字列表示
  - 属性配列の「|」区切り表示
  - 重複属性除去フィルタリング
  - ソースからの属性収集
  - 空属性時のクラス付与
  - toggleAttribution() の toggle 動作
  - updateCompact(): 小さいキャンバス（≤640px）
  - updateCompact(): 大きいキャンバス（>640px）
  - drag 時の compact-show 除去

## Test plan
- [x] 全94テストがパスすることを確認済み (`npx vitest run`)
- [x] `npx biome check` でlintエラーなし
- [x] TypeScript警告なし

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストは内部テストの改善のみを含み、ユーザー向けの新機能や変更はありません。

* **Tests**
  * 属性表示制御の動作検証に関するテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->