### PR TITLE
#37 add E2E tests for constructor options

### DIFF
--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -65,7 +65,9 @@ test.describe("Constructor options", () => {
 
     const hash = await page.evaluate(() => window.location.hash);
     // Hash format: #zoom/lat/lng or #zoom/lat/lng/bearing/pitch
-    expect(hash).toMatch(/^#\d/);
+    expect(hash).toMatch(
+      /^#\d+(?:\.\d+)?\/-?\d+(?:\.\d+)?\/-?\d+(?:\.\d+)?(?:\/-?\d+(?:\.\d+)?\/-?\d+(?:\.\d+)?)?$/,
+    );
   });
 
   test("should resolve Geolonia style with lang parameter", async ({
@@ -79,8 +81,10 @@ test.describe("Constructor options", () => {
     await page.goto(
       "/options.html?style=geolonia/basic-v2&lang=en&apiKey=YOUR-API-KEY",
     );
-    // Wait a bit for style request to be made (will 403 without valid API key, but URL is still requested)
-    await page.waitForTimeout(3000);
+    // Wait for style request to be made (will 403 without valid API key, but URL is still requested)
+    await expect
+      .poll(() => requests.length, { timeout: 10000 })
+      .toBeGreaterThan(0);
     dispose();
 
     const styleUrls = requests.map((r) => r.url());

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "@playwright/test";
+import { interceptRequests, waitForMapLoad } from "./helper";
+
+test.describe("Constructor options", () => {
+  test("should apply center and zoom", async ({ page }) => {
+    await page.goto("/options.html?center=[135.5,34.7]&zoom=10");
+    await waitForMapLoad(page);
+
+    const state = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getCenter: () => { lng: number; lat: number };
+        getZoom: () => number;
+      };
+      const c = map.getCenter();
+      return { lng: c.lng, lat: c.lat, zoom: map.getZoom() };
+    });
+
+    expect(state.lng).toBeCloseTo(135.5, 1);
+    expect(state.lat).toBeCloseTo(34.7, 1);
+    expect(state.zoom).toBeCloseTo(10, 0);
+  });
+
+  test("should apply minZoom and maxZoom", async ({ page }) => {
+    await page.goto("/options.html?minZoom=5&maxZoom=15");
+    await waitForMapLoad(page);
+
+    const limits = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getMinZoom: () => number;
+        getMaxZoom: () => number;
+      };
+      return { minZoom: map.getMinZoom(), maxZoom: map.getMaxZoom() };
+    });
+
+    expect(limits.minZoom).toBe(5);
+    expect(limits.maxZoom).toBe(15);
+  });
+
+  test("should apply bearing and pitch", async ({ page }) => {
+    await page.goto("/options.html?bearing=45&pitch=30");
+    await waitForMapLoad(page);
+
+    const state = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getBearing: () => number;
+        getPitch: () => number;
+      };
+      return { bearing: map.getBearing(), pitch: map.getPitch() };
+    });
+
+    expect(state.bearing).toBeCloseTo(45, 0);
+    expect(state.pitch).toBeCloseTo(30, 0);
+  });
+
+  test("should reflect map state in URL hash when hash is enabled", async ({
+    page,
+  }) => {
+    await page.goto("/options.html?hash=true&zoom=10&center=[139.7,35.6]");
+    await waitForMapLoad(page);
+
+    // Wait for hash to be written
+    await page.waitForFunction(() => window.location.hash.length > 1, {
+      timeout: 5000,
+    });
+
+    const hash = await page.evaluate(() => window.location.hash);
+    // Hash format: #zoom/lat/lng or #zoom/lat/lng/bearing/pitch
+    expect(hash).toMatch(/^#\d/);
+  });
+
+  test("should resolve Geolonia style with lang parameter", async ({
+    page,
+  }) => {
+    const { requests, dispose } = interceptRequests(
+      page,
+      "cdn.geolonia.com/style",
+    );
+
+    await page.goto(
+      "/options.html?style=geolonia/basic-v2&lang=en&apiKey=YOUR-API-KEY",
+    );
+    // Wait a bit for style request to be made (will 403 without valid API key, but URL is still requested)
+    await page.waitForTimeout(3000);
+    dispose();
+
+    const styleUrls = requests.map((r) => r.url());
+    expect(styleUrls.some((url) => url.includes("/en.json"))).toBe(true);
+  });
+
+  test("should resolve container from CSS selector", async ({ page }) => {
+    await page.goto("/options.html");
+    await waitForMapLoad(page);
+
+    const canvas = page.locator("#map canvas.maplibregl-canvas");
+    await expect(canvas).toBeVisible();
+  });
+
+  test("should resolve container from DOM element", async ({ page }) => {
+    await page.goto("/options.html");
+    await waitForMapLoad(page);
+
+    // Verify that the existing map stored its instance on the resolved DOM
+    // element, implying the container was resolved (either from CSS selector
+    // or from DOM element). Then construct a second map using a DOM element
+    // directly and verify it also resolves.
+    const rendered = await page.evaluate(async () => {
+      const GeoloniaMapCtor = (
+        document.getElementById("map") as HTMLElement & {
+          geoloniaMap?: { constructor: unknown };
+        }
+      )?.geoloniaMap?.constructor as
+        | (new (
+            opts: Record<string, unknown>,
+          ) => {
+            on: (ev: string, cb: () => void) => void;
+          })
+        | undefined;
+      if (!GeoloniaMapCtor) return false;
+
+      const div = document.createElement("div");
+      div.id = "map2";
+      div.style.width = "400px";
+      div.style.height = "300px";
+      document.body.appendChild(div);
+
+      const map2 = new GeoloniaMapCtor({
+        container: div,
+        style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+        center: [139.7671, 35.6812],
+        zoom: 10,
+        navigationControl: false,
+        geoloniaControl: false,
+        gestureHandling: false,
+        loader: false,
+      });
+
+      return new Promise<boolean>((resolve) => {
+        map2.on("load", () => {
+          const canvas = div.querySelector("canvas.maplibregl-canvas");
+          resolve(canvas !== null);
+        });
+        setTimeout(() => resolve(false), 15000);
+      });
+    });
+
+    expect(rendered).toBe(true);
+  });
+});

--- a/example/options.ts
+++ b/example/options.ts
@@ -1,11 +1,12 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
 import { GeoloniaMap } from "../src/index";
 
 // Read options from URL search params so e2e tests can configure dynamically
 const params = new URLSearchParams(window.location.search);
 
-const map = new GeoloniaMap({
+const options: GeoloniaMapOptions = {
   container: "#map",
   style:
     params.get("style") ||
@@ -14,16 +15,22 @@ const map = new GeoloniaMap({
     ? JSON.parse(params.get("center")!)
     : [139.7671, 35.6812],
   zoom: params.has("zoom") ? Number(params.get("zoom")) : 12,
-  minZoom: params.has("minZoom") ? Number(params.get("minZoom")) : undefined,
-  maxZoom: params.has("maxZoom") ? Number(params.get("maxZoom")) : undefined,
-  bearing: params.has("bearing") ? Number(params.get("bearing")) : undefined,
-  pitch: params.has("pitch") ? Number(params.get("pitch")) : undefined,
-  hash: params.get("hash") === "true",
-  lang: (params.get("lang") as "ja" | "en" | "auto") || undefined,
   navigationControl: false,
   geoloniaControl: false,
   gestureHandling: false,
   loader: false,
-});
+};
+
+if (params.has("minZoom")) options.minZoom = Number(params.get("minZoom"));
+if (params.has("maxZoom")) options.maxZoom = Number(params.get("maxZoom"));
+if (params.has("bearing")) options.bearing = Number(params.get("bearing"));
+if (params.has("pitch")) options.pitch = Number(params.get("pitch"));
+if (params.get("hash") === "true") options.hash = true;
+if (params.has("lang")) {
+  options.lang = params.get("lang") as "ja" | "en" | "auto";
+}
+if (params.has("apiKey")) options.apiKey = params.get("apiKey")!;
+
+const map = new GeoloniaMap(options);
 
 (window as unknown as Record<string, unknown>).map = map;


### PR DESCRIPTION
Fixes #37

## Summary
- `e2e/options.spec.ts` を新規作成、7件のテストケースを実装
  - center / zoom
  - minZoom / maxZoom
  - bearing / pitch
  - hash: URLハッシュへの状態反映
  - lang: 解決後のスタイルURLに `/en.json` が含まれる
  - CSSセレクタでコンテナ解決
  - DOM要素でコンテナ解決
- `example/options.ts` を修正: 未指定パラメータは `undefined` を明示的に渡さず、オプション辞書に含めないように変更。これにより `minZoom: undefined` 等がMapLibreの内部で `Invalid LngLat object: (NaN, NaN)` を引き起こす問題を回避
- `apiKey` URL パラメータを追加（lang テストで Geolonia スタイル解決に必要）

## Test plan
- [x] `npm run test`（ユニットテスト 93件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（22件 全てパス）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * マップコンストラクタオプションの設定と動作検証を行う新しいE2Eテストスイートを追加しました。クエリパラメータ経由でのオプション指定、ハッシュ挙動、スタイル解決、コンテナ指定などを検証します。

* **ドキュメント**
  * マップオプション設定の使用例を更新し、URLパラメータ（apiKey、言語など）による動的な設定方法を示すようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->