### PR TITLE
#38 expand E2E tests for marker and popup

### DIFF
--- a/e2e/marker-popup.spec.ts
+++ b/e2e/marker-popup.spec.ts
@@ -26,4 +26,50 @@ test.describe("Marker and Popup", () => {
       .evaluate((el) => (el as HTMLElement).style.fill);
     expect(fill).toContain("rgb"); // tinycolor converts to rgb
   });
+
+  test("should not render marker when marker: false", async ({ page }) => {
+    await page.goto("/marker-popup.html?marker=false");
+    await waitForMapLoad(page);
+    const marker = page.locator(".geolonia-default-marker");
+    await expect(marker).toHaveCount(0);
+  });
+
+  test("should show popup initially when openPopup: true", async ({ page }) => {
+    await waitForMapLoad(page);
+    const popup = page.locator(".maplibregl-popup");
+    await expect(popup).toBeVisible();
+    await expect(popup.locator(".test-popup")).toHaveText("Hello Tokyo");
+  });
+
+  test("should use custom marker element when customMarker is set", async ({
+    page,
+  }) => {
+    await page.goto("/marker-popup.html?customMarker=%23custom-marker");
+    await waitForMapLoad(page);
+
+    // The custom element should have been moved into the map as a marker,
+    // and display:none should have been cleared
+    const customMarker = page.locator(
+      ".maplibregl-marker#custom-marker, #custom-marker.maplibregl-marker",
+    );
+    await expect(customMarker).toBeVisible();
+    // Default marker should not exist since customMarker is used
+    const defaultMarker = page.locator(".geolonia-default-marker");
+    await expect(defaultMarker).toHaveCount(0);
+  });
+
+  test("should toggle popup on marker click", async ({ page }) => {
+    await page.goto("/marker-popup.html?openPopup=false");
+    await waitForMapLoad(page);
+
+    const popup = page.locator(".maplibregl-popup");
+    await expect(popup).toHaveCount(0);
+
+    const marker = page.locator(".geolonia-clickable-marker").first();
+    await marker.click();
+    await expect(popup).toBeVisible();
+
+    await marker.click();
+    await expect(popup).toHaveCount(0);
+  });
 });

--- a/example/marker-popup.ts
+++ b/example/marker-popup.ts
@@ -1,25 +1,34 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
 import { GeoloniaMap } from "../src/index";
 
-// Test 1: Default marker with openPopup
-const map1 = new GeoloniaMap({
+// Read options from URL search params so e2e tests can configure dynamically
+const params = new URLSearchParams(window.location.search);
+
+const options: GeoloniaMapOptions = {
   container: "#map",
   style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
   center: [139.7671, 35.6812],
   zoom: 14,
-  marker: true,
-  markerColor: "#FF0000",
-  openPopup: true,
+  marker: params.get("marker") !== "false",
+  markerColor: params.get("markerColor") || "#FF0000",
+  openPopup: params.get("openPopup") !== "false",
   gestureHandling: false,
   geoloniaControl: false,
   loader: false,
-});
+};
 
-// Set popup content via dataset (simulating embed behavior)
+if (params.has("customMarker")) {
+  options.customMarker = params.get("customMarker")!;
+}
+
+// Set popup content via dataset unless disabled
 const mapEl = document.querySelector("#map");
-if (mapEl instanceof HTMLElement) {
+if (mapEl instanceof HTMLElement && params.get("popupContent") !== "false") {
   mapEl.dataset.popupContent = '<p class="test-popup">Hello Tokyo</p>';
 }
 
-(window as unknown as Record<string, unknown>).map = map1;
+const map = new GeoloniaMap(options);
+
+(window as unknown as Record<string, unknown>).map = map;


### PR DESCRIPTION
Fixes #38

## Summary
- `e2e/marker-popup.spec.ts` に4件追加（既存3件を維持）
  - `marker: false` でマーカー非表示
  - `openPopup: true` でポップアップが初期表示（内容確認込み）
  - `customMarker` で指定要素がマーカーとして使用される
  - マーカークリックでポップアップ開閉
- `example/marker-popup.ts` を URL パラメータ駆動にリファクタ（`marker`, `markerColor`, `openPopup`, `customMarker`, `popupContent`）

## Test plan
- [x] `npm run test`（ユニットテスト 93件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（19件 全てパス）