### PR TITLE
#42 add comment clarifying GeoloniaControl placement intent

### DIFF
--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -222,6 +222,8 @@ export default class GeoloniaMap extends maplibregl.Map {
     this.__styleExtensionLoadRequired = true;
 
     // Controls
+    // Note: GeoloniaControl should be placed before another controls.
+    // Because this control should be "very" bottom-left(default) or the attributed position.
     const geoloniaCtrl = parseControlOption(options.geoloniaControl ?? true);
     this.addControl(
       new GeoloniaControl(),


### PR DESCRIPTION
Fixes #42

## Summary
`src/lib/geolonia-map.ts` の GeoloniaControl 追加箇所に、geolonia/embed と同じ意図コメントを追記:

```
// Note: GeoloniaControl should be placed before another controls.
// Because this control should be "very" bottom-left(default) or the attributed position.
```

GeoloniaControl は他のコントロールと違って `enabled` ガードなしに常に addControl される設計になっているが、これは **バグではなくブランディング表示を保証するための意図的な仕様**。参考: https://github.com/geolonia/embed/blob/master/src/lib/geolonia-map.ts#L200

今後の読み手が「他コントロールと違って `enabled` チェックがない」と勘違いしないようコメントで明示する。

## Test plan
- コメント追加のみ、動作変更なし