### PR TITLE
#25 SimpleStyle の追加テスト

### DIFF
--- a/test/simplestyle.test.ts
+++ b/test/simplestyle.test.ts
@@ -240,13 +240,13 @@ describe("SimpleStyle", () => {
   it("should unregister all events on remove()", async () => {
     const { SimpleStyle } = await import("../src/lib/simplestyle");
     const map = new MockMap();
+    const onSpy = vi.spyOn(map, "on");
     const offSpy = vi.spyOn(map, "off");
     const ss = new SimpleStyle(geojson).addTo(map);
 
     ss.remove();
 
-    // 4 popup layers × 3 events + 1 cluster layer × 3 events = 15
-    expect(offSpy.mock.calls.length).toBe(15);
+    expect(offSpy.mock.calls.length).toBe(onSpy.mock.calls.length);
   });
 
   it("should be safe to call remove() twice", async () => {
@@ -281,6 +281,7 @@ describe("SimpleStyle", () => {
     const clusterLayer = map.layers.find(
       (l) => l.id === "geolonia-simple-style-clusters",
     ) as { paint: Record<string, unknown> };
+    expect(clusterLayer).toBeDefined();
     expect(clusterLayer.paint["circle-color"]).toBe("#00ff00");
   });
 
@@ -293,8 +294,16 @@ describe("SimpleStyle", () => {
     const clickCalls = onSpy.mock.calls.filter(
       (call) => call[0] === "click" && typeof call[2] === "function",
     );
-    // polygon, linestring, circle-points, symbol-points, clusters = 5
-    expect(clickCalls.length).toBe(5);
+    const layers = clickCalls.map(([, layer]) => layer).sort();
+    expect(layers).toEqual(
+      [
+        "geolonia-simple-style-polygon",
+        "geolonia-simple-style-linestring",
+        "geolonia-simple-style-circle-points",
+        "geolonia-simple-style-symbol-points",
+        "geolonia-simple-style-clusters",
+      ].sort(),
+    );
   });
 
   it("should separate Point features from Polygon/LineString into different sources", async () => {

--- a/test/simplestyle.test.ts
+++ b/test/simplestyle.test.ts
@@ -1,14 +1,20 @@
 /**
  * @vitest-environment jsdom
  */
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { MockMap } from "./helpers/mock-map";
+
+const originalCreateObjectURL = window.URL.createObjectURL;
 
 beforeAll(() => {
   // maplibre-gl tries URL.createObjectURL on import
   if (!window.URL.createObjectURL) {
     window.URL.createObjectURL = () => "blob:mock";
   }
+});
+
+afterAll(() => {
+  window.URL.createObjectURL = originalCreateObjectURL;
 });
 
 const geojson = {
@@ -215,5 +221,127 @@ describe("SimpleStyle", () => {
     expect(symbolLayer).toBeDefined();
     expect(symbolLayer.layout["icon-allow-overlap"]).toBe(true);
     expect(symbolLayer.layout["text-allow-overlap"]).toBe(true);
+  });
+
+  it("should remove all layers and sources on remove()", async () => {
+    const { SimpleStyle } = await import("../src/lib/simplestyle");
+    const map = new MockMap();
+    const ss = new SimpleStyle(geojson).addTo(map);
+
+    expect(map.layers.length).toBe(8);
+    expect(Object.keys(map.sources).length).toBe(2);
+
+    ss.remove();
+
+    expect(map.layers.length).toBe(0);
+    expect(Object.keys(map.sources).length).toBe(0);
+  });
+
+  it("should unregister all events on remove()", async () => {
+    const { SimpleStyle } = await import("../src/lib/simplestyle");
+    const map = new MockMap();
+    const offSpy = vi.spyOn(map, "off");
+    const ss = new SimpleStyle(geojson).addTo(map);
+
+    ss.remove();
+
+    // 4 popup layers × 3 events + 1 cluster layer × 3 events = 15
+    expect(offSpy.mock.calls.length).toBe(15);
+  });
+
+  it("should be safe to call remove() twice", async () => {
+    const { SimpleStyle } = await import("../src/lib/simplestyle");
+    const map = new MockMap();
+    const ss = new SimpleStyle(geojson).addTo(map);
+
+    ss.remove();
+    expect(() => ss.remove()).not.toThrow();
+  });
+
+  it("should create cluster layers", async () => {
+    const { SimpleStyle } = await import("../src/lib/simplestyle");
+    const map = new MockMap();
+    new SimpleStyle(geojson).addTo(map);
+
+    const clusterLayer = map.layers.find(
+      (l) => l.id === "geolonia-simple-style-clusters",
+    );
+    const clusterCountLayer = map.layers.find(
+      (l) => l.id === "geolonia-simple-style-cluster-count",
+    );
+    expect(clusterLayer).toBeDefined();
+    expect(clusterCountLayer).toBeDefined();
+  });
+
+  it("should apply cluster color", async () => {
+    const { SimpleStyle } = await import("../src/lib/simplestyle");
+    const map = new MockMap();
+    new SimpleStyle(geojson, { clusterColor: "#00ff00" }).addTo(map);
+
+    const clusterLayer = map.layers.find(
+      (l) => l.id === "geolonia-simple-style-clusters",
+    ) as { paint: Record<string, unknown> };
+    expect(clusterLayer.paint["circle-color"]).toBe("#00ff00");
+  });
+
+  it("should register click events for popup and cluster layers", async () => {
+    const { SimpleStyle } = await import("../src/lib/simplestyle");
+    const map = new MockMap();
+    const onSpy = vi.spyOn(map, "on");
+    new SimpleStyle(geojson).addTo(map);
+
+    const clickCalls = onSpy.mock.calls.filter(
+      (call) => call[0] === "click" && typeof call[2] === "function",
+    );
+    // polygon, linestring, circle-points, symbol-points, clusters = 5
+    expect(clickCalls.length).toBe(5);
+  });
+
+  it("should separate Point features from Polygon/LineString into different sources", async () => {
+    const mixedGeojson = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: { type: "Point", coordinates: [139.77, 35.68] },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [139.0, 35.0],
+                [140.0, 35.0],
+                [140.0, 36.0],
+                [139.0, 36.0],
+                [139.0, 35.0],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+
+    const { SimpleStyle } = await import("../src/lib/simplestyle");
+    const map = new MockMap();
+    new SimpleStyle(mixedGeojson).addTo(map);
+
+    const mainSource = map.sources["geolonia-simple-style"] as {
+      data: { features: { geometry: { type: string } }[] };
+    };
+    const pointsSource = map.sources["geolonia-simple-style-points"] as {
+      data: { features: { geometry: { type: string } }[] };
+    };
+
+    // Main source should have only Polygon (non-Point features)
+    expect(mainSource.data.features.length).toBe(1);
+    expect(mainSource.data.features[0].geometry.type).toBe("Polygon");
+
+    // Points source should have only Point features
+    expect(pointsSource.data.features.length).toBe(1);
+    expect(pointsSource.data.features[0].geometry.type).toBe("Point");
   });
 });


### PR DESCRIPTION
## Summary
- `test/simplestyle.test.ts` に7テストケースを追加（既存8件 → 15件）
- `afterAll` で `URL.createObjectURL` を復元
- テストケース:
  - remove() でレイヤー・ソース全削除（8レイヤー + 2ソース）
  - remove() でイベント解除（15ハンドラ）
  - remove() 後の再呼び出し安全性
  - クラスタレイヤー生成（clusters + cluster-count）
  - クラスタ色適用
  - click イベント登録数（5レイヤー: popup 4 + cluster 1）
  - Point と Polygon/LineString の分離

## Test plan
- [x] 全100テストがパスすることを確認済み (`npx vitest run`)
- [x] `npx biome check` でlintエラーなし

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * スタイル削除機能に関するテストカバレッジが拡大されました。
  * クラスタリング機能の動作検証テストが追加されました。
  * データおよびソース分離処理のテストが追加されました。
  * テスト実行環境のクリーンアップ処理が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->