### PR TITLE
#26 maplibre-util.ts の追加テスト

### DIFF
--- a/test/maplibre-util.test.ts
+++ b/test/maplibre-util.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { bindAll, DOM } from "../src/lib/maplibre-util";
 
 describe("DOM.create", () => {
@@ -167,20 +167,30 @@ describe("DOM.addEventListener / removeEventListener", () => {
   });
 
   it("should add and remove event listener with capture option", () => {
-    const target = document.createElement("div");
+    const parent = document.createElement("div");
+    const child = document.createElement("div");
+    parent.appendChild(child);
+    document.body.appendChild(parent);
     const callback = vi.fn();
 
-    DOM.addEventListener(target, "click", callback, { capture: true });
-    target.dispatchEvent(new Event("click"));
+    DOM.addEventListener(parent, "click", callback, { capture: true });
+    child.dispatchEvent(new Event("click", { bubbles: true }));
     expect(callback).toHaveBeenCalledTimes(1);
 
-    DOM.removeEventListener(target, "click", callback, { capture: true });
-    target.dispatchEvent(new Event("click"));
+    DOM.removeEventListener(parent, "click", callback, { capture: true });
+    child.dispatchEvent(new Event("click", { bubbles: true }));
     expect(callback).toHaveBeenCalledTimes(1);
+    parent.remove();
   });
 });
 
 describe("DOM.disableDrag / enableDrag", () => {
+  const originalUserSelect = document.documentElement.style.userSelect;
+
+  afterEach(() => {
+    document.documentElement.style.userSelect = originalUserSelect;
+  });
+
   it("should disable and re-enable user-select", () => {
     const style = document.documentElement.style;
     style.userSelect = "auto";

--- a/test/maplibre-util.test.ts
+++ b/test/maplibre-util.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { bindAll, DOM } from "../src/lib/maplibre-util";
 
 describe("DOM.create", () => {
@@ -141,6 +141,55 @@ describe("DOM.mouseButton", () => {
   it("should return the mouse button value", () => {
     const event = new MouseEvent("mousedown", { button: 2 });
     expect(DOM.mouseButton(event)).toBe(2);
+  });
+});
+
+describe("DOM.setTransform", () => {
+  it("should set the transform style property", () => {
+    const el = document.createElement("div");
+    DOM.setTransform(el, "translate(10px, 20px)");
+    expect(el.style.transform).toBe("translate(10px, 20px)");
+  });
+});
+
+describe("DOM.addEventListener / removeEventListener", () => {
+  it("should add and remove event listener with passive option", () => {
+    const target = document.createElement("div");
+    const callback = vi.fn();
+
+    DOM.addEventListener(target, "click", callback, { passive: true });
+    target.dispatchEvent(new Event("click"));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    DOM.removeEventListener(target, "click", callback, { passive: true });
+    target.dispatchEvent(new Event("click"));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should add and remove event listener with capture option", () => {
+    const target = document.createElement("div");
+    const callback = vi.fn();
+
+    DOM.addEventListener(target, "click", callback, { capture: true });
+    target.dispatchEvent(new Event("click"));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    DOM.removeEventListener(target, "click", callback, { capture: true });
+    target.dispatchEvent(new Event("click"));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DOM.disableDrag / enableDrag", () => {
+  it("should disable and re-enable user-select", () => {
+    const style = document.documentElement.style;
+    style.userSelect = "auto";
+
+    DOM.disableDrag();
+    expect(style.userSelect).toBe("none");
+
+    DOM.enableDrag();
+    expect(style.userSelect).toBe("auto");
   });
 });
 


### PR DESCRIPTION
## Summary
- `test/maplibre-util.test.ts` に4テストケースを追加（既存14件 → 18件）
- テストケース:
  - setTransform(): style.transform 設定確認
  - addEventListener() / removeEventListener(): passive オプションでのリスナー追加・削除
  - addEventListener() / removeEventListener(): capture オプションでのリスナー追加・削除
  - disableDrag() / enableDrag(): userSelect の none / 元値 切り替え

## Test plan
- [x] 全97テストがパスすることを確認済み (`npx vitest run`)
- [x] `npx biome check` でlintエラーなし

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * DOM ユーティリティのテストカバレッジを拡充しました。スタイル変更、イベントリスナーの追加・削除、ドラッグ有効化・無効化などの動作検証を追加しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->