### PR TITLE
#27 keyring の境界値テスト追加 + isGeoloniaStyleCheck バグ修正

### DIFF
--- a/src/lib/keyring.ts
+++ b/src/lib/keyring.ts
@@ -52,6 +52,14 @@ class Keyring {
       return false;
     }
 
+    // geolonia:// is a Geolonia protocol, other non-http protocols are not
+    if (style.startsWith("geolonia://")) {
+      return true;
+    }
+    if (style.match(/^[a-z][a-z0-9+.-]*:\/\//i)) {
+      return false;
+    }
+
     if (style.endsWith(".json")) {
       return false;
     }

--- a/test/keyring.test.ts
+++ b/test/keyring.test.ts
@@ -70,5 +70,17 @@ describe("keyring", () => {
       expect(keyring.isGeoloniaStyleCheck("geolonia/basic-v2")).toBe(true);
       expect(keyring.isGeoloniaStyleCheck("geolonia/gsi")).toBe(true);
     });
+
+    it('should return true for "geolonia://" prefix', () => {
+      expect(keyring.isGeoloniaStyleCheck("geolonia://tiles/custom/test")).toBe(
+        true,
+      );
+    });
+
+    it('should return false for "pmtiles://" prefix', () => {
+      expect(
+        keyring.isGeoloniaStyleCheck("pmtiles://example.com/tiles.pmtiles"),
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `test/keyring.test.ts` に2つの境界値テストケースを追加（既存11件 → 13件）
  - `"geolonia://"` プレフィックス → `true` 返却
  - `"pmtiles://"` プレフィックス → `false` 返却

### バグ修正: `isGeoloniaStyleCheck` の非HTTPプロトコルURL誤判定
境界値テスト追加時に `isGeoloniaStyleCheck` のバグを発見・修正しました。

**問題**: `pmtiles://` などの非HTTP/HTTPSプロトコルURLが、`^https?://` パターンにマッチせずフォールスルーし、Geolonia論理名（`return true`）として誤判定されていた。

**修正**: `src/lib/keyring.ts` に以下のロジックを追加
- `geolonia://` で始まる場合は明示的に `true` を返す（Geolonia固有プロトコル）
- それ以外のプロトコルURL（`^[a-z][a-z0-9+.-]*://`）は `false` を返す

## Test plan
- [x] 全95ユニットテストがパスすることを確認済み (`npx vitest run`)
- [x] 全22 e2eテストがパスすることを確認済み (`npx playwright test`)
- [x] `npx biome check` でlintエラーなし

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `geolonia://` スキームの URL 処理に対応しました。

* **改善**
  * 非 HTTP(S) プロトコルの処理ロジックを改善しました。

* **テスト**
  * URL スキーム処理の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->