### PR TITLE
#28 getStyle の境界値テスト追加 + ja-jp 言語コード修正

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -52,7 +52,7 @@ export function getStyle(
   }
 
   if (!style || style === "") {
-    return `https://cdn.geolonia.com/style/geolonia/basic-v2/${lang === "ja" ? "ja" : "en"}.json`;
+    return `https://cdn.geolonia.com/style/geolonia/basic-v2/${lang === "ja" || lang === "ja-jp" ? "ja" : "en"}.json`;
   }
 
   const styleUrl = isURL(style);
@@ -69,7 +69,7 @@ export function getStyle(
   }
 
   // Geolonia logical name like "geolonia/basic-v2"
-  return `https://cdn.geolonia.com/style/${style}/${lang === "ja" ? "ja" : "en"}.json`;
+  return `https://cdn.geolonia.com/style/${style}/${lang === "ja" || lang === "ja-jp" ? "ja" : "en"}.json`;
 }
 
 /**

--- a/test/getStyle.test.ts
+++ b/test/getStyle.test.ts
@@ -73,4 +73,22 @@ describe("getStyle - edge cases", () => {
       getStyle("geolonia/basic-v2", { lang: "fr" as "en", apiKey: "test-key" }),
     ).toContain("/en.json");
   });
+
+  it("should attempt base URL resolution for .json filename (non-URL)", () => {
+    const result = getStyle("my-style.json", {
+      lang: "ja",
+      apiKey: "test-key",
+    });
+    // In jsdom without a real location, falls back to returning the filename as-is
+    expect(result).toContain("my-style.json");
+  });
+
+  it('should treat "ja-jp" language code as "ja"', () => {
+    expect(
+      getStyle("geolonia/basic-v2", {
+        lang: "ja-jp",
+        apiKey: "test-key",
+      }),
+    ).toContain("/ja.json");
+  });
 });


### PR DESCRIPTION
## Summary
- `test/getStyle.test.ts` に2つの境界値テストケースを追加（既存10件 → 12件）
  - `.json` ファイル名（非URL）のベースURL解決試行
  - `"ja-jp"` 言語コードが `"ja"` として処理される

### バグ修正: `getStyle` の `"ja-jp"` 言語コード誤判定
境界値テスト追加時にバグを発見・修正しました。

**問題**: `getLang()` は `"ja-jp"` → `"ja"` と正しく処理するが、`getStyle` 内部の言語比較は `lang === "ja"` のみで `"ja-jp"` を考慮していなかったため、`"ja-jp"` が渡されると英語スタイルが返されていた。

**修正**: `src/lib/util.ts` の `getStyle` 内の言語比較2箇所を `lang === "ja" || lang === "ja-jp"` に変更。

## Test plan
- [x] 全95ユニットテストがパスすることを確認済み (`npx vitest run`)
- [x] 全22 e2eテストがパスすることを確認済み (`npx playwright test`)
- [x] `npx biome check` でlintエラーなし

Closes #28