### PR TITLE
#52 add E2E tests for apiKey, sessionId, and stage

### DIFF
--- a/e2e/authentication.spec.ts
+++ b/e2e/authentication.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+import { interceptRequests } from "./helper";
+
+test.describe("Authentication (apiKey, sessionId, stage, transformRequest)", () => {
+  test("should append key= to Geolonia tile requests", async ({ page }) => {
+    const { requests, dispose } = interceptRequests(
+      page,
+      /api\.geolonia\.com|tileserver(-dev)?\.geolonia\.com/,
+    );
+    await page.goto("/geolonia-style.html");
+    await expect
+      .poll(() => requests.length, { timeout: 10000 })
+      .toBeGreaterThan(0);
+    dispose();
+
+    const urlsWithKey = requests
+      .map((r) => r.url())
+      .filter((url) => new URL(url).searchParams.has("key"));
+    expect(urlsWithKey.length).toBeGreaterThan(0);
+  });
+
+  test("should append sessionId= to Geolonia tile requests", async ({
+    page,
+  }) => {
+    const { requests, dispose } = interceptRequests(
+      page,
+      /api\.geolonia\.com|tileserver(-dev)?\.geolonia\.com/,
+    );
+    await page.goto("/geolonia-style.html");
+    await expect
+      .poll(() => requests.length, { timeout: 10000 })
+      .toBeGreaterThan(0);
+    dispose();
+
+    const urlsWithSession = requests
+      .map((r) => r.url())
+      .filter((url) => new URL(url).searchParams.has("sessionId"));
+    expect(urlsWithSession.length).toBeGreaterThan(0);
+  });
+
+  test("should NOT append key/sessionId to non-Geolonia tile URLs", async ({
+    page,
+  }) => {
+    const { requests, dispose } = interceptRequests(
+      page,
+      "tile.openstreetmap.jp",
+    );
+    await page.goto("/auth-external.html");
+    await expect
+      .poll(() => requests.length, { timeout: 10000 })
+      .toBeGreaterThan(0);
+    dispose();
+
+    for (const req of requests) {
+      const url = new URL(req.url());
+      expect(url.searchParams.has("key")).toBe(false);
+      expect(url.searchParams.has("sessionId")).toBe(false);
+    }
+  });
+
+  test("should reflect stage option in API path", async ({ page }) => {
+    const { requests, dispose } = interceptRequests(page, "api.geolonia.com");
+    await page.goto("/geolonia-style.html?stage=v1");
+    await expect
+      .poll(() => requests.length, { timeout: 10000 })
+      .toBeGreaterThan(0);
+    dispose();
+
+    // Every api.geolonia.com request should hit /v1/ path, not /dev/
+    const v1Urls = requests
+      .map((r) => r.url())
+      .filter((url) => new URL(url).pathname.startsWith("/v1/"));
+    expect(v1Urls.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/authentication.spec.ts
+++ b/e2e/authentication.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { interceptRequests } from "./helper";
 
-test.describe("Authentication (apiKey, sessionId, stage, transformRequest)", () => {
+test.describe("Authentication (apiKey, sessionId, stage)", () => {
   test("should append key= to Geolonia tile requests", async ({ page }) => {
     const { requests, dispose } = interceptRequests(
       page,
@@ -67,9 +67,8 @@ test.describe("Authentication (apiKey, sessionId, stage, transformRequest)", () 
     dispose();
 
     // Every api.geolonia.com request should hit /v1/ path, not /dev/
-    const v1Urls = requests
-      .map((r) => r.url())
-      .filter((url) => new URL(url).pathname.startsWith("/v1/"));
-    expect(v1Urls.length).toBeGreaterThan(0);
+    const paths = requests.map((r) => new URL(r.url()).pathname);
+    expect(paths.some((p) => p.startsWith("/v1/"))).toBe(true);
+    expect(paths.every((p) => !p.startsWith("/dev/"))).toBe(true);
   });
 });

--- a/example/auth-external.html
+++ b/example/auth-external.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Auth External E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/auth-external.ts"></script>
+</body>
+</html>

--- a/example/auth-external.ts
+++ b/example/auth-external.ts
@@ -1,0 +1,19 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import { GeoloniaMap } from "../src/index";
+
+// Map with apiKey set but using an external (non-Geolonia) style.
+// Used to verify the API key is NOT appended to non-Geolonia tile URLs.
+const map = new GeoloniaMap({
+  container: "#map",
+  apiKey: "YOUR-API-KEY",
+  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  center: [139.7671, 35.6812],
+  zoom: 12,
+  marker: false,
+  gestureHandling: false,
+  loader: false,
+  navigationControl: false,
+});
+
+(window as unknown as Record<string, unknown>).map = map;

--- a/example/geolonia-style.ts
+++ b/example/geolonia-style.ts
@@ -1,16 +1,23 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
 import { GeoloniaMap } from "../src/index";
 
-const map = new GeoloniaMap({
+const params = new URLSearchParams(window.location.search);
+
+const options: GeoloniaMapOptions = {
   container: "#map",
-  apiKey: "YOUR-API-KEY",
-  style: "geolonia/basic-v2",
+  apiKey: params.get("apiKey") || "YOUR-API-KEY",
+  style: params.get("style") || "geolonia/basic-v2",
   center: [139.7671, 35.6812],
   zoom: 14,
   marker: false,
   gestureHandling: false,
   loader: false,
-});
+};
+
+if (params.has("stage")) options.stage = params.get("stage")!;
+
+const map = new GeoloniaMap(options);
 
 (window as unknown as Record<string, unknown>).map = map;


### PR DESCRIPTION
Fixes #52

## Summary
- `e2e/authentication.spec.ts` を新規作成、4件のテストを実装
  - Geolonia タイルリクエストに `key=` パラメータが付与される
  - Geolonia タイルリクエストに `sessionId=` パラメータが付与される
  - 外部タイルURL（OSM等）には `key`/`sessionId` が**付与されない**
  - `stage` オプションが API パスに反映される（`/v1/` 等）
- `example/geolonia-style.ts` を URL パラメータ駆動にリファクタ（`apiKey`, `stage`, `style`）。デフォルト値は従来と同じため既存テスト（`e2e/geolonia-style.spec.ts`）は無修正で動作
- `example/auth-external.{html,ts}` を新規作成（apiKey 設定済みで style のみ外部 OSM）

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（37件 全パス）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 認証周りのエンドツーエンドテストを追加しました（リクエストの書き換えや認証クエリの付与／非付与を検証）。

* **ドキュメント・サンプル**
  * 認証の実演用サンプルページとスクリプトを追加しました（外部スタイル使用、明示的なAPIキー指定）。
  * クエリパラメータでマップ設定（APIキー・スタイル・ステージなど）を上書き可能にしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->