### PR TITLE
#53 add E2E tests for GeoJSON / SimpleStyle

### DIFF
--- a/e2e/geojson.spec.ts
+++ b/e2e/geojson.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+import {
+  collectConsoleErrors,
+  hasLayer,
+  hasSource,
+  waitForMapLoad,
+} from "./helper";
+
+test.describe("GeoJSON / SimpleStyle", () => {
+  test("should add source and layer when geojson URL is provided", async ({
+    page,
+  }) => {
+    await page.goto("/geojson.html?source=url");
+    await waitForMapLoad(page);
+
+    // SimpleStyle adds sources: `geolonia-simple-style` and `...-points`
+    expect(await hasSource(page, "geolonia-simple-style")).toBe(true);
+    expect(await hasSource(page, "geolonia-simple-style-points")).toBe(true);
+    // At least one SimpleStyle layer should exist (symbol-points is created
+    // for Point features).
+    expect(await hasLayer(page, "geolonia-simple-style-symbol-points")).toBe(
+      true,
+    );
+  });
+
+  test("should render data when geojson object is passed directly", async ({
+    page,
+  }) => {
+    await page.goto("/geojson.html"); // default: inline object
+    await waitForMapLoad(page);
+
+    expect(await hasSource(page, "geolonia-simple-style-points")).toBe(true);
+    const featureCount = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getSource: (
+          id: string,
+        ) => { _data?: { features?: unknown[] } } | undefined;
+      };
+      const src = map.getSource("geolonia-simple-style-points");
+      return src?._data?.features?.length ?? 0;
+    });
+    expect(featureCount).toBe(3);
+  });
+
+  test("should add cluster layers when cluster: true", async ({ page }) => {
+    await page.goto("/geojson.html?cluster=true");
+    await waitForMapLoad(page);
+
+    expect(await hasLayer(page, "geolonia-simple-style-clusters")).toBe(true);
+    expect(await hasLayer(page, "geolonia-simple-style-cluster-count")).toBe(
+      true,
+    );
+  });
+
+  test("should fit bounds to GeoJSON when center is not specified", async ({
+    page,
+  }) => {
+    await page.goto("/geojson.html?noCenter=true");
+    await waitForMapLoad(page);
+
+    // Allow a little time for fitBounds to animate
+    await page.waitForTimeout(500);
+
+    const center = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getCenter: () => { lng: number; lat: number };
+      };
+      const c = map.getCenter();
+      return { lng: c.lng, lat: c.lat };
+    });
+
+    // Feature centroid is roughly around 139.72, 35.68 (Tokyo area).
+    // Default center in options.ts is 139.7671, 35.6812 — when unset,
+    // MapLibre defaults to [0, 0]. fitBounds should move it to Tokyo.
+    expect(center.lng).toBeGreaterThan(139);
+    expect(center.lng).toBeLessThan(140);
+    expect(center.lat).toBeGreaterThan(35);
+    expect(center.lat).toBeLessThan(36);
+  });
+
+  test("should handle fetch failure gracefully", async ({ page }) => {
+    const errors = collectConsoleErrors(page);
+    await page.goto("/geojson.html?source=bad");
+    await waitForMapLoad(page);
+
+    // Map should still be alive (loaded() returned true via waitForMapLoad)
+    const mapAlive = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as
+        | { loaded: () => boolean }
+        | undefined;
+      return !!map?.loaded?.();
+    });
+    expect(mapAlive).toBe(true);
+    // An error should have been logged for the failed GeoJSON load
+    expect(errors.some((e) => e.includes("Failed to load GeoJSON"))).toBe(true);
+  });
+});

--- a/example/geojson.html
+++ b/example/geojson.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GeoJSON / SimpleStyle E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/geojson.ts"></script>
+</body>
+</html>

--- a/example/geojson.ts
+++ b/example/geojson.ts
@@ -1,0 +1,62 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
+import { GeoloniaMap } from "../src/index";
+
+const params = new URLSearchParams(window.location.search);
+
+const inlineGeoJSON: GeoJSON.FeatureCollection = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: { title: "Tokyo Station" },
+      geometry: { type: "Point", coordinates: [139.767, 35.681] },
+    },
+    {
+      type: "Feature",
+      properties: { title: "Shinjuku" },
+      geometry: { type: "Point", coordinates: [139.7, 35.689] },
+    },
+    {
+      type: "Feature",
+      properties: { title: "Shibuya" },
+      geometry: { type: "Point", coordinates: [139.701, 35.659] },
+    },
+  ],
+};
+
+const options: GeoloniaMapOptions = {
+  container: "#map",
+  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  zoom: 12,
+  marker: false,
+  gestureHandling: false,
+  geoloniaControl: false,
+  loader: false,
+  navigationControl: false,
+};
+
+// Default center unless explicitly testing fitBounds (?noCenter=true)
+if (params.get("noCenter") !== "true") {
+  options.center = [139.7671, 35.6812];
+}
+
+// Source: "url" fetches from /sample.geojson, "bad" points to 404,
+// otherwise (default) passes the object directly.
+const source = params.get("source") || "inline";
+if (source === "url") {
+  options.geojson = "/sample.geojson";
+} else if (source === "bad") {
+  options.geojson = "/does-not-exist.geojson";
+} else {
+  options.geojson = inlineGeoJSON;
+}
+
+if (params.has("cluster")) {
+  options.cluster = params.get("cluster") === "true";
+}
+
+const map = new GeoloniaMap(options);
+
+(window as unknown as Record<string, unknown>).map = map;

--- a/example/sample.geojson
+++ b/example/sample.geojson
@@ -1,0 +1,20 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "title": "Tokyo Station" },
+      "geometry": { "type": "Point", "coordinates": [139.767, 35.681] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "title": "Shinjuku" },
+      "geometry": { "type": "Point", "coordinates": [139.700, 35.689] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "title": "Shibuya" },
+      "geometry": { "type": "Point", "coordinates": [139.701, 35.659] }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #53

## Summary
- `e2e/geojson.spec.ts` を新規作成、5件のテストを実装
  - `geojson` URL 指定時にソース/レイヤーが追加される
  - `geojson` オブジェクトを直接渡して3件の feature が描画される
  - `cluster: true` でクラスタレイヤーが存在する
  - `center` 未指定時に `fitBounds()` が発動し東京周辺にズームイン
  - GeoJSON 取得失敗時にマップがクラッシュせず、コンソールエラーが記録される
- `example/geojson.{html,ts}`（URLパラメータ駆動）と `example/sample.geojson`（3点fixture）を追加

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（38件 全パス）