### PR TITLE
#54 add E2E tests for SimpleStyleVector

### DIFF
--- a/e2e/vector-tiles.spec.ts
+++ b/e2e/vector-tiles.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+import { hasSource, waitForMapLoad } from "./helper";
+
+test.describe("SimpleStyleVector", () => {
+  // Stub the vector tile (.pbf) requests so they don't 404 noisily.
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/tiles/**/*.pbf", (route) => {
+      route.fulfill({ status: 204, body: "" });
+    });
+  });
+
+  test("should add vector source when simpleVector is provided", async ({
+    page,
+  }) => {
+    await page.goto("/simple-vector.html");
+    await waitForMapLoad(page);
+
+    expect(await hasSource(page, "vt-geolonia-simple-style")).toBe(true);
+
+    const sourceType = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getSource: (id: string) => { type: string } | undefined;
+      };
+      return map.getSource("vt-geolonia-simple-style")?.type;
+    });
+    expect(sourceType).toBe("vector");
+  });
+
+  test("should fitBounds to source bounds when no center is specified", async ({
+    page,
+  }) => {
+    await page.goto("/simple-vector.html?noCenter=true");
+    await waitForMapLoad(page);
+
+    // Wait for source to load bounds and trigger fitBounds
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() => {
+            const map = (window as unknown as Record<string, unknown>).map as {
+              getCenter: () => { lng: number; lat: number };
+            };
+            return map.getCenter().lng;
+          }),
+        { timeout: 10000 },
+      )
+      .toBeGreaterThan(139);
+
+    const center = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getCenter: () => { lng: number; lat: number };
+      };
+      const c = map.getCenter();
+      return { lng: c.lng, lat: c.lat };
+    });
+
+    // Source bounds are [139.6, 35.55, 139.85, 35.75], so center should be in Tokyo
+    expect(center.lng).toBeGreaterThan(139.5);
+    expect(center.lng).toBeLessThan(140);
+    expect(center.lat).toBeGreaterThan(35.5);
+    expect(center.lat).toBeLessThan(35.8);
+  });
+
+  test("should add interactive feature layers for popup on click", async ({
+    page,
+  }) => {
+    await page.goto("/simple-vector.html");
+    await waitForMapLoad(page);
+
+    // SimpleStyleVector calls setPopup() on each of these layers, which
+    // registers click/mouseenter/mouseleave handlers. Actually triggering a
+    // popup requires real rendered vector features, which is out of scope for
+    // this test — verifying that the layers exist implies the handlers were
+    // wired up in addTo().
+    const layers = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getLayer: (id: string) => unknown;
+      };
+      return {
+        polygon: !!map.getLayer("vt-geolonia-simple-style-polygon"),
+        linestring: !!map.getLayer("vt-geolonia-simple-style-linestring"),
+        circlePoints: !!map.getLayer("vt-circle-simple-style-points"),
+        symbolPoints: !!map.getLayer("vt-geolonia-simple-style-points"),
+      };
+    });
+    expect(layers).toEqual({
+      polygon: true,
+      linestring: true,
+      circlePoints: true,
+      symbolPoints: true,
+    });
+  });
+});

--- a/example/sample-vector.json
+++ b/example/sample-vector.json
@@ -1,0 +1,19 @@
+{
+  "tilejson": "2.2.0",
+  "name": "sample-vector",
+  "minzoom": 0,
+  "maxzoom": 14,
+  "bounds": [139.6, 35.55, 139.85, 35.75],
+  "center": [139.7671, 35.6812, 10],
+  "tiles": ["http://localhost:5174/tiles/{z}/{x}/{y}.pbf"],
+  "vector_layers": [
+    {
+      "id": "g-simplestyle-v1",
+      "description": "sample simplestyle layer",
+      "fields": {
+        "title": "String",
+        "description": "String"
+      }
+    }
+  ]
+}

--- a/example/simple-vector.html
+++ b/example/simple-vector.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SimpleStyleVector E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/simple-vector.ts"></script>
+</body>
+</html>

--- a/example/simple-vector.ts
+++ b/example/simple-vector.ts
@@ -1,0 +1,28 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
+import { GeoloniaMap } from "../src/index";
+
+const params = new URLSearchParams(window.location.search);
+
+const options: GeoloniaMapOptions = {
+  container: "#map",
+  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  zoom: 6,
+  marker: false,
+  gestureHandling: false,
+  geoloniaControl: false,
+  loader: false,
+  navigationControl: false,
+  simpleVector:
+    params.get("simpleVector") || "http://localhost:5174/sample-vector.json",
+};
+
+// Only set center when explicitly asked, so fitBounds behavior can be tested.
+if (params.get("noCenter") !== "true") {
+  options.center = [139.7671, 35.6812];
+}
+
+const map = new GeoloniaMap(options);
+
+(window as unknown as Record<string, unknown>).map = map;


### PR DESCRIPTION
Fixes #54

## Summary
- `e2e/vector-tiles.spec.ts` を新規作成、3件のテストを実装
  - `simpleVector` 指定時にベクトルソースが追加される
  - `center` 未指定時に TileJSON の `bounds` で `fitBounds` される
  - インタラクティブなフィーチャーレイヤーが全種類（polygon/linestring/circle-points/symbol-points）追加される
- `example/simple-vector.{html,ts}`（URLパラメータ駆動）と最小TileJSON fixture `example/sample-vector.json` を追加
- `page.route` でPBFタイル要求をstub（実タイルがなくても source bounds が読めるよう）

## 備考
- フィーチャークリックでの**実際のポップアップ表示**は、実際にレンダリングされたベクトルタイルフィーチャーが必要になるため、本PRのスコープ外。レイヤー存在でラップアップ配線の確認としている（`setPopup()` は各レイヤーに対して無条件に呼ばれるため）

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（36件 全パス）