### PR TITLE
#58 add E2E tests for gesture handling

### DIFF
--- a/e2e/gesture-handling.spec.ts
+++ b/e2e/gesture-handling.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import { waitForMapLoad } from "./helper";
+
+async function wheelOverMap(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  const canvas = page.locator("canvas.maplibregl-canvas").first();
+  await canvas.scrollIntoViewIfNeeded();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("canvas not visible");
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  await page.mouse.move(cx, cy);
+  // Dispatch wheel events directly on the canvas element so MapLibre's
+  // scrollZoom handler (bound to the canvas) receives them.
+  await canvas.evaluate((el) => {
+    for (let i = 0; i < 5; i++) {
+      el.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: -120,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    }
+  });
+}
+
+test.describe("Gesture handling", () => {
+  test("should suppress wheel zoom on scrollable pages by default", async ({
+    page,
+  }) => {
+    await page.goto("/gesture.html");
+    await waitForMapLoad(page);
+
+    // Let the dynamic import of GestureHandling resolve
+    await page.waitForTimeout(500);
+
+    const initialZoom = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getZoom: () => number;
+      };
+      return map.getZoom();
+    });
+
+    await wheelOverMap(page);
+    await page.waitForTimeout(300);
+
+    const afterZoom = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getZoom: () => number;
+      };
+      return map.getZoom();
+    });
+
+    expect(afterZoom).toBeCloseTo(initialZoom, 2);
+  });
+
+  test("should allow wheel zoom when gestureHandling is false", async ({
+    page,
+  }) => {
+    await page.goto("/gesture.html?gestureHandling=false");
+    await waitForMapLoad(page);
+    await page.waitForTimeout(500);
+
+    const initialZoom = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getZoom: () => number;
+      };
+      return map.getZoom();
+    });
+
+    await wheelOverMap(page);
+    await page.waitForTimeout(300);
+
+    const afterZoom = await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getZoom: () => number;
+      };
+      return map.getZoom();
+    });
+
+    expect(afterZoom).toBeGreaterThan(initialZoom);
+  });
+});

--- a/example/gesture.html
+++ b/example/gesture.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gesture Handling E2E</title>
+  <style>
+    body { margin: 0; padding: 0; }
+    .spacer { height: 1200px; background: #eee; }
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div class="spacer">Scrollable content (top)</div>
+  <div id="map"></div>
+  <div class="spacer">Scrollable content (bottom)</div>
+  <script type="module" src="/gesture.ts"></script>
+</body>
+</html>

--- a/example/gesture.ts
+++ b/example/gesture.ts
@@ -1,0 +1,25 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
+import { GeoloniaMap } from "../src/index";
+
+const params = new URLSearchParams(window.location.search);
+
+const options: GeoloniaMapOptions = {
+  container: "#map",
+  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  center: [139.7671, 35.6812],
+  zoom: 10,
+  marker: false,
+  geoloniaControl: false,
+  loader: false,
+  navigationControl: false,
+};
+
+if (params.has("gestureHandling")) {
+  options.gestureHandling = params.get("gestureHandling") !== "false";
+}
+
+const map = new GeoloniaMap(options);
+
+(window as unknown as Record<string, unknown>).map = map;


### PR DESCRIPTION
Fixes #58

## Summary
- `e2e/gesture-handling.spec.ts` を新規作成、2件のテストを実装
  - デフォルト (`gestureHandling: true`) + スクロール可能ページでホイールズーム無効
  - `gestureHandling: false` でホイールズーム有効
- `example/gesture.{html,ts}` を追加（縦長 spacer でページをスクロール可能に）

## 実装メモ
- `GestureHandling` はページがスクロール可能な場合のみ発動する（`body.scrollHeight > body.clientHeight`）ため、テストページに高さ1200pxのspacerを上下に配置
- ホイールイベントは `page.mouse.wheel()` ではMapLibre側に届かなかったため、`canvas.evaluate` でcanvas要素に直接 `WheelEvent` をdispatch

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（35件 全パス）