### PR TITLE
#61 add E2E tests for multiple maps on the same page

### DIFF
--- a/e2e/multiple-maps.spec.ts
+++ b/e2e/multiple-maps.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { waitForMapLoadOn } from "./helper";
+
+test.describe("Multiple maps on the same page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/multiple-maps.html");
+    await waitForMapLoadOn(page, "#map-a");
+    await waitForMapLoadOn(page, "#map-b");
+  });
+
+  test("should render both maps independently", async ({ page }) => {
+    const canvasA = page.locator("#map-a canvas.maplibregl-canvas");
+    const canvasB = page.locator("#map-b canvas.maplibregl-canvas");
+    await expect(canvasA).toBeVisible();
+    await expect(canvasB).toBeVisible();
+
+    const centers = await page.evaluate(() => {
+      const w = window as unknown as Record<
+        string,
+        { getCenter: () => { lng: number; lat: number } }
+      >;
+      return {
+        a: w.mapA.getCenter(),
+        b: w.mapB.getCenter(),
+      };
+    });
+    // mapA centered on Tokyo, mapB on Osaka — they must differ
+    expect(centers.a.lng).toBeCloseTo(139.7671, 1);
+    expect(centers.b.lng).toBeCloseTo(135.5023, 1);
+  });
+
+  test("should use different styles per map", async ({ page }) => {
+    const styles = await page.evaluate(() => {
+      const w = window as unknown as Record<
+        string,
+        { getStyle: () => { name?: string; sprite?: string } }
+      >;
+      return {
+        a: w.mapA.getStyle(),
+        b: w.mapB.getStyle(),
+      };
+    });
+    // Two different style JSONs should produce different style objects
+    // (distinguishable by name or sprite URL)
+    expect(JSON.stringify(styles.a)).not.toBe(JSON.stringify(styles.b));
+  });
+
+  test("should prevent double initialization on the same container", async ({
+    page,
+  }) => {
+    const sameInstance = await page.evaluate(() => {
+      const w = window as unknown as Record<string, unknown>;
+      return w.mapA === w.mapADup;
+    });
+    expect(sameInstance).toBe(true);
+
+    // Container should have only one canvas (no second map was mounted)
+    const canvasCount = await page
+      .locator("#map-a canvas.maplibregl-canvas")
+      .count();
+    expect(canvasCount).toBe(1);
+  });
+});

--- a/example/multiple-maps.html
+++ b/example/multiple-maps.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multiple Maps E2E</title>
+  <style>
+    body { margin: 0; padding: 16px; }
+    .map { width: 100%; height: 300px; margin-bottom: 16px; }
+  </style>
+</head>
+<body>
+  <div id="map-a" class="map"></div>
+  <div id="map-b" class="map"></div>
+  <script type="module" src="/multiple-maps.ts"></script>
+</body>
+</html>

--- a/example/multiple-maps.ts
+++ b/example/multiple-maps.ts
@@ -1,0 +1,43 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import { GeoloniaMap } from "../src/index";
+
+const osmStyle = "https://tile.openstreetmap.jp/styles/osm-bright/style.json";
+const vtStyle =
+  "https://tile.openstreetmap.jp/styles/maptiler-toner-en/style.json";
+
+const commonOptions = {
+  zoom: 10,
+  marker: false,
+  geoloniaControl: false,
+  gestureHandling: false,
+  loader: false,
+  navigationControl: false,
+};
+
+const mapA = new GeoloniaMap({
+  container: "#map-a",
+  style: osmStyle,
+  center: [139.7671, 35.6812],
+  ...commonOptions,
+});
+
+const mapB = new GeoloniaMap({
+  container: "#map-b",
+  style: vtStyle,
+  center: [135.5023, 34.6937],
+  ...commonOptions,
+});
+
+// Attempt a double initialization on the same container for the "prevents
+// double init" test. Should return the existing mapA instance, not create a
+// new one.
+const mapADup = new GeoloniaMap({
+  container: "#map-a",
+  style: osmStyle,
+  ...commonOptions,
+});
+
+(window as unknown as Record<string, unknown>).mapA = mapA;
+(window as unknown as Record<string, unknown>).mapB = mapB;
+(window as unknown as Record<string, unknown>).mapADup = mapADup;


### PR DESCRIPTION
Fixes #61

## Summary
- `e2e/multiple-maps.spec.ts` を新規作成、3件のテストを実装
  - 2つのmap (Tokyo / Osaka) が独立して描画される
  - それぞれ異なるスタイル JSON を使用している
  - 同一コンテナに対する二重初期化が防止され、既存インスタンスが返る
- `example/multiple-maps.{html,ts}` を追加
  - `#map-a` (osm-bright, Tokyo) と `#map-b` (maptiler-toner, Osaka)
  - `#map-a` に対してもう一度 `new GeoloniaMap` を試み、同一インスタンスが返ることを検証用に保持

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（41件 全パス）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 同一ページ上で複数のマップインスタンスを独立して配置・管理できるようになりました。

* **Documentation**
  * 複数マップの初期化方法を示すサンプルコード（HTMLおよびTypeScript）を追加しました。

* **Tests**
  * 複数マップのシナリオ（独立レンダリング、スタイル分離、初期化処理）をカバーするエンドツーエンドテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->