### PR TITLE
#62 add E2E tests for setStyle() / remove() lifecycle

### DIFF
--- a/e2e/lifecycle.spec.ts
+++ b/e2e/lifecycle.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import { interceptRequests, waitForMapLoad } from "./helper";
+
+test.describe("setStyle() / remove() lifecycle", () => {
+  test("setStyle() should swap to a new style and request its tiles", async ({
+    page,
+  }) => {
+    await page.goto("/lifecycle.html");
+    await waitForMapLoad(page);
+
+    const { requests, dispose } = interceptRequests(page, "maptiler-toner-en");
+    await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        setStyle: (url: string) => void;
+      };
+      map.setStyle(
+        "https://tile.openstreetmap.jp/styles/maptiler-toner-en/style.json",
+      );
+    });
+
+    await expect
+      .poll(() => requests.length, { timeout: 10000 })
+      .toBeGreaterThan(0);
+    dispose();
+  });
+
+  test("setStyle() with a Geolonia logical name should resolve to CDN URL", async ({
+    page,
+  }) => {
+    await page.goto("/lifecycle.html");
+    await waitForMapLoad(page);
+
+    const { requests, dispose } = interceptRequests(
+      page,
+      "cdn.geolonia.com/style",
+    );
+    await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        setStyle: (name: string) => void;
+      };
+      map.setStyle("geolonia/basic-v2");
+    });
+
+    await expect
+      .poll(() => requests.length, { timeout: 10000 })
+      .toBeGreaterThan(0);
+    dispose();
+
+    const urls = requests.map((r) => r.url());
+    expect(urls.some((u) => u.includes("/style/geolonia/basic-v2/"))).toBe(
+      true,
+    );
+  });
+
+  test("remove() should clear canvas and container.geoloniaMap", async ({
+    page,
+  }) => {
+    await page.goto("/lifecycle.html");
+    await waitForMapLoad(page);
+
+    await expect(page.locator("canvas.maplibregl-canvas")).toHaveCount(1);
+
+    await page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        remove: () => void;
+      };
+      map.remove();
+    });
+
+    await expect(page.locator("canvas.maplibregl-canvas")).toHaveCount(0);
+    const hasGeoloniaMap = await page.evaluate(() => {
+      const container = document.querySelector("#map") as HTMLElement & {
+        geoloniaMap?: unknown;
+      };
+      return container.geoloniaMap !== undefined;
+    });
+    expect(hasGeoloniaMap).toBe(false);
+  });
+});

--- a/example/lifecycle.html
+++ b/example/lifecycle.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lifecycle E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/lifecycle.ts"></script>
+</body>
+</html>

--- a/example/lifecycle.ts
+++ b/example/lifecycle.ts
@@ -1,0 +1,20 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import { GeoloniaMap } from "../src/index";
+
+// Initialize with an apiKey so that keyring.apiKey is set — required for
+// setStyle() with a Geolonia logical name to resolve to the CDN URL.
+const map = new GeoloniaMap({
+  container: "#map",
+  apiKey: "YOUR-API-KEY",
+  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  center: [139.7671, 35.6812],
+  zoom: 12,
+  marker: false,
+  geoloniaControl: false,
+  gestureHandling: false,
+  loader: false,
+  navigationControl: false,
+});
+
+(window as unknown as Record<string, unknown>).map = map;


### PR DESCRIPTION
Fixes #62

## Summary
- `e2e/lifecycle.spec.ts` を新規作成、3件のテストを実装
  - `setStyle(url)` で新スタイルのタイルがリクエストされる
  - `setStyle("geolonia/basic-v2")` が CDN URL (`cdn.geolonia.com/style/geolonia/basic-v2/`) に解決される
  - `remove()` で canvas が消え、`container.geoloniaMap` が undefined になる
- `example/lifecycle.{html,ts}` を追加
  - 初期化時に `apiKey: "YOUR-API-KEY"` を設定（`setStyle` で Geolonia 論理名を使う際に `keyring.apiKey` のガードを通すため）

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（41件 全パス）