### PR TITLE
#51 maplibre-gesture-handling v3.0.0 に移行

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@geolonia/mbgl-gesture-handling": "^1.0.15",
+        "@geolonia/maplibre-gesture-handling": "^3.0.0",
         "@turf/bbox": "^7.3.4",
         "@turf/center": "^7.3.4",
         "pmtiles": "^4.4.0",
@@ -908,11 +908,14 @@
         }
       }
     },
-    "node_modules/@geolonia/mbgl-gesture-handling": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@geolonia/mbgl-gesture-handling/-/mbgl-gesture-handling-1.0.15.tgz",
-      "integrity": "sha512-etY8yCd2eAiZ/7kONFPLKAjFo1IQ1IICwhocCATD8I1peAeKmo3lEFGoRomeMkLKhiJOAeE/Uoy5gzyrQRj7lg==",
-      "license": "MIT"
+    "node_modules/@geolonia/maplibre-gesture-handling": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/maplibre-gesture-handling/-/maplibre-gesture-handling-3.0.0.tgz",
+      "integrity": "sha512-V0LvBr4nxoxXBcVYMrpTH8s9eyT4cumRLKYL/RXq+X8jA5c4hSjx0dHURZFi884qqEI0neIPzxdmS975DqV6hA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=2.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -957,7 +960,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
       "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "get-stream": "^6.0.1",
@@ -971,7 +973,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -980,28 +981,24 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
       "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
       "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
       "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
@@ -1013,7 +1010,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
@@ -1023,14 +1019,12 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
       "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
       "version": "23.3.0",
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.3.0.tgz",
       "integrity": "sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
@@ -1051,7 +1045,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
       "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
@@ -1528,7 +1521,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
       "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
@@ -1548,7 +1540,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
       "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
@@ -1976,7 +1967,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/entities": {
@@ -2127,14 +2117,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2147,7 +2135,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/has-flag": {
@@ -2316,14 +2303,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lilconfig": {
@@ -2408,7 +2393,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.0.tgz",
       "integrity": "sha512-Hs+Y0qbR1iZo+07WuSbYUCOOUK45pPRzA3+7Pes8Y9jCcAqZendIMcVP6O99CWD1V/znh3qHgaZOAi3jlVxwcg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -2453,7 +2437,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2483,7 +2466,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2580,7 +2562,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
       "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -2746,14 +2727,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
       "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
       "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -2770,7 +2749,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/readdirp": {
@@ -2811,7 +2789,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
@@ -2866,7 +2843,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sanitize-html": {
@@ -2976,7 +2952,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "kdbush": "^4.0.2"
@@ -3066,7 +3041,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/tinyrainbow": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "src/assets/style.css"
   ],
   "dependencies": {
-    "@geolonia/mbgl-gesture-handling": "^1.0.15",
+    "@geolonia/maplibre-gesture-handling": "^3.0.0",
     "@turf/bbox": "^7.3.4",
     "@turf/center": "^7.3.4",
     "pmtiles": "^4.4.0",

--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -272,7 +272,7 @@ export default class GeoloniaMap extends maplibregl.Map {
 
       // Gesture handling
       if (options.gestureHandling !== false) {
-        import("@geolonia/mbgl-gesture-handling")
+        import("@geolonia/maplibre-gesture-handling")
           .then(({ default: GestureHandling }) => {
             const body = document.body;
             const html = document.documentElement;
@@ -280,7 +280,7 @@ export default class GeoloniaMap extends maplibregl.Map {
               body.scrollHeight > body.clientHeight ||
               html.scrollHeight > html.clientHeight;
             if (isScrollable) {
-              new GestureHandling({ lang }).addTo(map);
+              map.addControl(new GestureHandling({ lang }));
             }
           })
           .catch(() => {

--- a/src/lib/vendor.d.ts
+++ b/src/lib/vendor.d.ts
@@ -1,6 +1,0 @@
-declare module "@geolonia/mbgl-gesture-handling" {
-  export default class GestureHandling {
-    constructor(options?: { lang?: string });
-    addTo(map: any): void;
-  }
-}


### PR DESCRIPTION
## Summary
- `@geolonia/mbgl-gesture-handling` を削除し、`@geolonia/maplibre-gesture-handling@3.0.0` をインストール
- `src/lib/geolonia-map.ts`: import先を変更、新パッケージが `IControl` を実装しているため `.addTo(map)` → `map.addControl()` に変更
- `src/lib/vendor.d.ts` を削除（新パッケージに TypeScript 型定義が同梱されているため不要）

## Test plan
- [x] 全131ユニットテストがパスすることを確認済み (`npx vitest run`)
- [x] 全38 e2eテスト（gesture-handling テスト含む）がパスすることを確認済み (`npx playwright test`)
- [x] `npx biome check` で新規lintエラーなし

Closes #51