### PR TITLE
#69 add E2E tests for CustomAttributionControl

### DIFF
--- a/e2e/attribution.spec.ts
+++ b/e2e/attribution.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import { waitForMapLoad } from "./helper";
+
+test.describe("Custom Attribution Control", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForMapLoad(page);
+  });
+
+  test("should render attribution text inside a Shadow DOM", async ({
+    page,
+  }) => {
+    // The CustomAttributionControl mounts a <div> whose shadow root contains
+    // <details class="maplibregl-ctrl maplibregl-ctrl-attrib"> with inner
+    // text (OpenMapTiles / OpenStreetMap contributors, etc.).
+    const info = await page.evaluate(() => {
+      const ctrls = document.querySelectorAll(
+        ".maplibregl-ctrl-bottom-right > div",
+      );
+      for (const el of Array.from(ctrls)) {
+        if (el.shadowRoot) {
+          const details = el.shadowRoot.querySelector(
+            "details.maplibregl-ctrl-attrib",
+          );
+          const inner = el.shadowRoot.querySelector(
+            ".maplibregl-ctrl-attrib-inner",
+          );
+          return {
+            hasShadow: true,
+            hasDetails: !!details,
+            innerText: inner?.textContent || "",
+          };
+        }
+      }
+      return { hasShadow: false, hasDetails: false, innerText: "" };
+    });
+
+    expect(info.hasShadow).toBe(true);
+    expect(info.hasDetails).toBe(true);
+    expect(info.innerText.length).toBeGreaterThan(0);
+  });
+
+  test("should not render MapLibre's default attribution in light DOM", async ({
+    page,
+  }) => {
+    // MapLibre's built-in attribution would be a light-DOM <details> element
+    // as a direct child of .maplibregl-ctrl-bottom-right. Our CustomAttribution
+    // puts its <details> inside a shadow root of a wrapper <div> instead, so
+    // no top-level <details class="maplibregl-ctrl-attrib"> should exist in
+    // light DOM.
+    const lightDomDetails = await page.evaluate(() => {
+      // Exclude shadow roots — querySelectorAll does not pierce shadow DOM
+      return document.querySelectorAll(
+        ".maplibregl-ctrl-bottom-right > details.maplibregl-ctrl-attrib",
+      ).length;
+    });
+    expect(lightDomDetails).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #69

## Summary
- `e2e/attribution.spec.ts` を新規作成、2件のテストを実装
  - Attribution が Shadow DOM 内に描画される（wrapper div の shadow root 内に `<details class="maplibregl-ctrl-attrib">` + テキスト）
  - MapLibre デフォルトの light-DOM attribution は無効化（`.maplibregl-ctrl-bottom-right > details` が存在しない）
- 既存の `example/index.html` を流用（新規 fixture 不要）

## 実装メモ
- Shadow DOM 内要素は `page.evaluate()` で `el.shadowRoot.querySelector(...)` 経由でアクセス
- `querySelectorAll` は shadow DOM を貫通しないので、light-DOM 限定のチェックに利用

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（40件 全パス）