### PR TITLE
#70 add E2E tests for 3D mode layer visibility

### DIFF
--- a/e2e/3d-layers.spec.ts
+++ b/e2e/3d-layers.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { waitForMapLoad } from "./helper";
+
+async function getVisibility(
+  page: import("@playwright/test").Page,
+  layerId: string,
+): Promise<string | undefined> {
+  return page.evaluate((id: string) => {
+    const map = (window as unknown as Record<string, unknown>).map as {
+      getLayoutProperty: (id: string, prop: string) => string | undefined;
+    };
+    return map.getLayoutProperty(id, "visibility");
+  }, layerId);
+}
+
+test.describe("3D mode", () => {
+  test('should set visible-on-3d layers to "visible" when "3d": true', async ({
+    page,
+  }) => {
+    await page.goto("/3d.html?3d=true");
+    await waitForMapLoad(page);
+
+    // fixture: "show-on-3d-layer" starts with visibility: "none" and has
+    // metadata["visible-on-3d"] = true, so 3d mode should flip it to "visible".
+    expect(await getVisibility(page, "show-on-3d-layer")).toBe("visible");
+
+    // Sanity check: with 3d off, the same layer stays "none"
+    await page.goto("/3d.html");
+    await waitForMapLoad(page);
+    expect(await getVisibility(page, "show-on-3d-layer")).toBe("none");
+  });
+
+  test('should set hide-on-3d layers to "none" when "3d": true', async ({
+    page,
+  }) => {
+    await page.goto("/3d.html?3d=true");
+    await waitForMapLoad(page);
+
+    // fixture: "hide-on-3d-layer" has no initial visibility (defaults to
+    // visible) and has metadata["hide-on-3d"] = true, so 3d mode should flip
+    // it to "none".
+    expect(await getVisibility(page, "hide-on-3d-layer")).toBe("none");
+
+    // Sanity check: with 3d off, visibility is undefined (= default visible)
+    await page.goto("/3d.html");
+    await waitForMapLoad(page);
+    const v = await getVisibility(page, "hide-on-3d-layer");
+    expect(v === undefined || v === "visible").toBe(true);
+  });
+});

--- a/example/3d.html
+++ b/example/3d.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/3d.ts"></script>
+</body>
+</html>

--- a/example/3d.ts
+++ b/example/3d.ts
@@ -1,0 +1,26 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
+import { GeoloniaMap } from "../src/index";
+
+const params = new URLSearchParams(window.location.search);
+
+const options: GeoloniaMapOptions = {
+  container: "#map",
+  style: "/sample-3d-style.json",
+  center: [139.7671, 35.6812],
+  zoom: 10,
+  marker: false,
+  geoloniaControl: false,
+  gestureHandling: false,
+  loader: false,
+  navigationControl: false,
+};
+
+if (params.get("3d") === "true") {
+  options["3d"] = true;
+}
+
+const map = new GeoloniaMap(options);
+
+(window as unknown as Record<string, unknown>).map = map;

--- a/example/sample-3d-style.json
+++ b/example/sample-3d-style.json
@@ -1,0 +1,24 @@
+{
+  "version": 8,
+  "sources": {},
+  "layers": [
+    {
+      "id": "base-background",
+      "type": "background",
+      "paint": { "background-color": "#ffffff" }
+    },
+    {
+      "id": "show-on-3d-layer",
+      "type": "background",
+      "metadata": { "visible-on-3d": true },
+      "layout": { "visibility": "none" },
+      "paint": { "background-color": "#ff0000" }
+    },
+    {
+      "id": "hide-on-3d-layer",
+      "type": "background",
+      "metadata": { "hide-on-3d": true },
+      "paint": { "background-color": "#00ff00" }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #70

## Summary
- `e2e/3d-layers.spec.ts` を新規作成、2件のテストを実装
  - `"3d": true` 指定時、`metadata["visible-on-3d"]` のレイヤーが `visible` に切り替わる
  - `"3d": true` 指定時、`metadata["hide-on-3d"]` のレイヤーが `none` に切り替わる
  - いずれも `"3d": false`（デフォルト）では元の状態のままであることもサニティチェック
- `example/sample-3d-style.json` を新規作成: タイル不要の最小スタイル
  - `base-background`: 通常の背景
  - `show-on-3d-layer`: 初期 `visibility: none` + `visible-on-3d` metadata
  - `hide-on-3d-layer`: 初期 visible + `hide-on-3d` metadata
- `example/3d.{html,ts}` を追加（URL パラメータ `?3d=true` で切替）

## Test plan
- [x] `npm run test`（ユニットテスト 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（40件 全パス）