### PR TITLE
#66 maplibre-util.ts の tsc エラー修正

### DIFF
--- a/src/lib/maplibre-util.ts
+++ b/src/lib/maplibre-util.ts
@@ -51,22 +51,23 @@ export class DOM {
 
   static disableDrag(): void {
     if (DOM.#docStyle && DOM.#selectProp) {
-      DOM.#userSelect = (DOM.#docStyle as Record<string, string>)[
+      DOM.#userSelect = (DOM.#docStyle as unknown as Record<string, string>)[
         DOM.#selectProp
       ];
-      (DOM.#docStyle as Record<string, string>)[DOM.#selectProp] = "none";
+      (DOM.#docStyle as unknown as Record<string, string>)[DOM.#selectProp] =
+        "none";
     }
   }
 
   static enableDrag(): void {
     if (DOM.#docStyle && DOM.#selectProp) {
-      (DOM.#docStyle as Record<string, string>)[DOM.#selectProp] =
+      (DOM.#docStyle as unknown as Record<string, string>)[DOM.#selectProp] =
         DOM.#userSelect ?? "";
     }
   }
 
   static setTransform(el: HTMLElement, value: string): void {
-    (el.style as Record<string, string>)[DOM.#transformProp] = value;
+    (el.style as unknown as Record<string, string>)[DOM.#transformProp] = value;
   }
 
   static addEventListener(


### PR DESCRIPTION
## Summary
`src/lib/maplibre-util.ts` で `CSSStyleDeclaration` を `Record<string, string>` にキャストする4箇所で tsc エラー (TS2352) が発生していた問題を修正。

`as Record<string, string>` → `as unknown as Record<string, string>` に変更し、TypeScript の型オーバーラップチェックを通過させる。

対象箇所:
- `disableDrag()`: `DOM.#docStyle` の読み取りと書き込み (2箇所)
- `enableDrag()`: `DOM.#docStyle` の書き込み (1箇所)
- `setTransform()`: `el.style` の書き込み (1箇所)

## Test plan
- [x] `npx tsc --noEmit` でエラーゼロを確認
- [x] 全131ユニットテストパス (`npm run test`)
- [x] 全38 e2eテストパス (`npm run e2e`)
- [x] `npm run lint` で新規エラーなし

Closes #66