### PR TITLE
#67 lint 警告を修正 (40件 → 1件)

### DIFF
--- a/example/marker-popup.ts
+++ b/example/marker-popup.ts
@@ -20,7 +20,7 @@ const options: GeoloniaMapOptions = {
 };
 
 if (params.has("customMarker")) {
-  options.customMarker = params.get("customMarker")!;
+  options.customMarker = params.get("customMarker") ?? "";
 }
 
 // Set popup content via dataset unless disabled

--- a/example/options.ts
+++ b/example/options.ts
@@ -12,7 +12,7 @@ const options: GeoloniaMapOptions = {
     params.get("style") ||
     "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
   center: params.has("center")
-    ? JSON.parse(params.get("center")!)
+    ? JSON.parse(params.get("center") ?? "[]")
     : [139.7671, 35.6812],
   zoom: params.has("zoom") ? Number(params.get("zoom")) : 12,
   navigationControl: false,
@@ -29,7 +29,7 @@ if (params.get("hash") === "true") options.hash = true;
 if (params.has("lang")) {
   options.lang = params.get("lang") as "ja" | "en" | "auto";
 }
-if (params.has("apiKey")) options.apiKey = params.get("apiKey")!;
+if (params.has("apiKey")) options.apiKey = params.get("apiKey") ?? "";
 
 const map = new GeoloniaMap(options);
 

--- a/src/lib/controls/attribution.ts
+++ b/src/lib/controls/attribution.ts
@@ -168,10 +168,7 @@ class CustomAttributionControl implements IControl {
   private _shadowContainer: HTMLDetailsElement | undefined;
   private _innerContainer: HTMLElement | undefined;
   private _compactButton: HTMLElement | undefined;
-  private _editLink: HTMLAnchorElement | null = null;
   private _attribHTML: string | undefined;
-  private styleId: string | undefined;
-  private styleOwner: string | undefined;
   private printQuery: MediaQueryList | undefined;
   private onMediaPrintChange: ((e: MediaQueryListEvent) => void) | undefined;
 
@@ -235,8 +232,8 @@ class CustomAttributionControl implements IControl {
     this.printQuery = window.matchMedia("print");
     this.onMediaPrintChange = (e: MediaQueryListEvent) => {
       if (e.matches) {
-        this._shadowContainer!.setAttribute("open", "");
-        this._shadowContainer!.classList.remove("maplibregl-compact-show");
+        this._shadowContainer?.setAttribute("open", "");
+        this._shadowContainer?.classList.remove("maplibregl-compact-show");
       }
     };
     this.printQuery.addEventListener("change", this.onMediaPrintChange);
@@ -299,7 +296,7 @@ class CustomAttributionControl implements IControl {
   }
 
   _updateAttributions(): void {
-    if (!this._map || !this._map.style) return;
+    if (!this._map?.style) return;
 
     let attributions: string[] = [];
 
@@ -313,12 +310,6 @@ class CustomAttributionControl implements IControl {
       } else if (typeof this.options.customAttribution === "string") {
         attributions.push(this.options.customAttribution);
       }
-    }
-
-    if (this._map.style.stylesheet) {
-      const stylesheet = this._map.style.stylesheet;
-      this.styleOwner = stylesheet.owner;
-      this.styleId = stylesheet.id;
     }
 
     const sourceCaches = this._map.style.sourceCaches;
@@ -355,13 +346,12 @@ class CustomAttributionControl implements IControl {
     this._attribHTML = attribHTML;
 
     if (attributions.length) {
-      this._innerContainer!.innerHTML = attribHTML;
-      this._shadowContainer!.classList.remove("maplibregl-attrib-empty");
+      if (this._innerContainer) this._innerContainer.innerHTML = attribHTML;
+      this._shadowContainer?.classList.remove("maplibregl-attrib-empty");
     } else {
-      this._shadowContainer!.classList.add("maplibregl-attrib-empty");
+      this._shadowContainer?.classList.add("maplibregl-attrib-empty");
     }
     this._updateCompact();
-    this._editLink = null;
   }
 
   _updateCompact(): void {

--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -54,6 +54,7 @@ export default class GeoloniaMap extends maplibregl.Map {
   private geoloniaSourcesUrl!: URL;
   private __styleExtensionLoadRequired!: boolean;
 
+  // biome-ignore lint/correctness/noUnreachableSuper: intentional singleton pattern - returns existing map instance before super()
   constructor(options: GeoloniaMapOptions) {
     // Register PMTiles protocol on first map creation
     ensurePMTiles();
@@ -93,6 +94,7 @@ export default class GeoloniaMap extends maplibregl.Map {
     }
 
     if (container.geoloniaMap) {
+      // biome-ignore lint/correctness/noConstructorReturn: intentional singleton pattern
       return container.geoloniaMap;
     }
 
@@ -387,6 +389,7 @@ export default class GeoloniaMap extends maplibregl.Map {
 
     container.geoloniaMap = this;
 
+    // biome-ignore lint/correctness/noConstructorReturn: intentional singleton pattern
     return this;
   }
 

--- a/src/lib/simplestyle-vector.ts
+++ b/src/lib/simplestyle-vector.ts
@@ -1,5 +1,9 @@
 import turfCenter from "@turf/center";
-import maplibregl from "maplibre-gl";
+import maplibregl, {
+  type MapLayerMouseEvent,
+  type Map as MaplibreMap,
+  type MapSourceDataEvent,
+} from "maplibre-gl";
 import { sanitizeDescription } from "./util";
 
 const textColor = "#000000";
@@ -14,8 +18,7 @@ class SimpleStyleVector {
     this.sourceName = "vt-geolonia-simple-style";
   }
 
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  addTo(map: any) {
+  addTo(map: MaplibreMap) {
     const container = map.getContainer();
 
     if (
@@ -23,7 +26,7 @@ class SimpleStyleVector {
       (!container.dataset.lng && !container.dataset.lat)
     ) {
       let initialZoomDone = false;
-      map.on("sourcedata", (event: any) => {
+      map.on("sourcedata", (event: MapSourceDataEvent) => {
         // skip events for sources that don't concern us
         if (event.sourceId !== this.sourceName) {
           return;
@@ -32,7 +35,7 @@ class SimpleStyleVector {
         const source = map.getSource(event.sourceId);
         // query the map to see if the source is actually loaded or not. We can't trust `isSourceLoaded` in the event
         // because it's unreliable and often incorrect.
-        const isLoaded = source && source.loaded();
+        const isLoaded = source?.loaded();
 
         if (isLoaded !== true) {
           return;
@@ -44,10 +47,14 @@ class SimpleStyleVector {
         }
         initialZoomDone = true;
 
-        map.fitBounds(source.bounds, {
-          duration: 0,
-          padding: 30,
-        });
+        map.fitBounds(
+          (source as unknown as { bounds: [number, number, number, number] })
+            .bounds,
+          {
+            duration: 0,
+            padding: 30,
+          },
+        );
       });
     }
 
@@ -116,7 +123,7 @@ class SimpleStyleVector {
    *
    * @param map
    */
-  setPolygonGeometries(map: any) {
+  setPolygonGeometries(map: MaplibreMap) {
     map.addLayer({
       id: "vt-geolonia-simple-style-polygon",
       type: "fill",
@@ -138,7 +145,7 @@ class SimpleStyleVector {
    *
    * @param map
    */
-  setLineGeometries(map: any) {
+  setLineGeometries(map: MaplibreMap) {
     map.addLayer({
       id: "vt-geolonia-simple-style-linestring",
       type: "line",
@@ -164,7 +171,7 @@ class SimpleStyleVector {
    *
    * @param map
    */
-  setPointGeometries(map: any) {
+  setPointGeometries(map: MaplibreMap) {
     map.addLayer({
       id: "vt-circle-simple-style-points",
       type: "circle",
@@ -226,11 +233,12 @@ class SimpleStyleVector {
     this.setPopup(map, "vt-geolonia-simple-style-points");
   }
 
-  async setPopup(map: any, source: string) {
-    map.on("click", source, async (e: any) => {
+  async setPopup(map: MaplibreMap, source: string) {
+    map.on("click", source, async (e: MapLayerMouseEvent) => {
+      if (!e.features?.[0]) return;
       const center: [number, number] = turfCenter(e.features[0]).geometry
         .coordinates as [number, number];
-      const description = e.features[0].properties.description;
+      const description = e.features[0].properties?.description;
 
       if (description) {
         const sanitizedDescription = await sanitizeDescription(description);
@@ -241,8 +249,8 @@ class SimpleStyleVector {
       }
     });
 
-    map.on("mouseenter", source, (e: any) => {
-      if (e.features[0].properties.description) {
+    map.on("mouseenter", source, (e: MapLayerMouseEvent) => {
+      if (e.features?.[0]?.properties?.description) {
         map.getCanvas().style.cursor = "pointer";
       }
     });

--- a/src/lib/simplestyle.ts
+++ b/src/lib/simplestyle.ts
@@ -1,34 +1,49 @@
 import bbox from "@turf/bbox";
 import turfCenter from "@turf/center";
-import maplibregl from "maplibre-gl";
+import maplibregl, {
+  type GeoJSONSource,
+  type MapLayerEventType,
+  type MapLayerMouseEvent,
+  type Map as MaplibreMap,
+} from "maplibre-gl";
 import { isURL, sanitizeDescription } from "./util";
+
+type FeatureCollection = GeoJSON.FeatureCollection;
 
 const textColor = "#000000";
 const textHaloColor = "#FFFFFF";
 const backgroundColor = "rgba(255, 0, 0, 0.4)";
 const strokeColor = "#FFFFFF";
 
-const template = {
+const template: FeatureCollection = {
   type: "FeatureCollection",
   features: [],
 };
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+interface SimpleStyleOptions {
+  id: string;
+  cluster: boolean;
+  heatmap: boolean;
+  clusterColor: string;
+  [key: string]: unknown;
+}
+
 export class SimpleStyle {
   public _loadingPromise: Promise<unknown> | undefined;
   private callFitBounds = false;
-  private geojson: any;
-  private map: any;
-  private options: any;
+  private geojson!: FeatureCollection;
+  private map!: MaplibreMap;
+  private options: SimpleStyleOptions;
   private _eventHandlers: {
-    event: string;
+    event: keyof MapLayerEventType;
     layer: string;
+    // biome-ignore lint/suspicious/noExplicitAny: handlers have varying signatures
     handler: (...args: any[]) => void;
   }[] = [];
 
   constructor(
-    geojson: string | GeoJSON.GeoJSON,
-    options?: Record<string, any>,
+    geojson: string | FeatureCollection,
+    options?: Record<string, unknown>,
   ) {
     this.setGeoJSON(geojson);
 
@@ -41,39 +56,45 @@ export class SimpleStyle {
     };
   }
 
-  updateData(geojson: any) {
+  updateData(geojson: FeatureCollection) {
     this.setGeoJSON(geojson);
 
     const features = this.geojson.features;
     const polygonAndLines = features.filter(
-      (feature: any) => feature.geometry.type.toLowerCase() !== "point",
+      (feature: GeoJSON.Feature) =>
+        feature.geometry.type.toLowerCase() !== "point",
     );
     const points = features.filter(
-      (feature: any) => feature.geometry.type.toLowerCase() === "point",
+      (feature: GeoJSON.Feature) =>
+        feature.geometry.type.toLowerCase() === "point",
     );
 
-    this.map.getSource(this.options.id).setData({
+    (this.map.getSource(this.options.id) as GeoJSONSource)?.setData({
       type: "FeatureCollection",
       features: polygonAndLines,
     });
 
-    this.map.getSource(`${this.options.id}-points`).setData({
-      type: "FeatureCollection",
-      features: points,
-    });
+    (this.map.getSource(`${this.options.id}-points`) as GeoJSONSource)?.setData(
+      {
+        type: "FeatureCollection",
+        features: points,
+      },
+    );
 
     return this;
   }
 
-  addTo(map: any) {
+  addTo(map: MaplibreMap) {
     this.map = map;
 
     const features = this.geojson.features;
     const polygonAndLines = features.filter(
-      (feature: any) => feature.geometry.type.toLowerCase() !== "point",
+      (feature: GeoJSON.Feature) =>
+        feature.geometry.type.toLowerCase() !== "point",
     );
     const points = features.filter(
-      (feature: any) => feature.geometry.type.toLowerCase() === "point",
+      (feature: GeoJSON.Feature) =>
+        feature.geometry.type.toLowerCase() === "point",
     );
 
     this.map.addSource(this.options.id, {
@@ -279,13 +300,14 @@ export class SimpleStyle {
     this.setPopup(this.map, `${this.options.id}-symbol-points`);
   }
 
-  async setPopup(map: any, source: string) {
-    const clickHandler = async (e: any) => {
+  async setPopup(map: MaplibreMap, source: string) {
+    const clickHandler = async (e: MapLayerMouseEvent) => {
+      if (!e.features?.[0]) return;
       const center = turfCenter(e.features[0]).geometry.coordinates as [
         number,
         number,
       ];
-      const description = e.features[0].properties.description;
+      const description = e.features[0].properties?.description;
 
       if (description) {
         const sanitizedDescription = await sanitizeDescription(description);
@@ -296,8 +318,8 @@ export class SimpleStyle {
       }
     };
 
-    const mouseEnterHandler = (e: any) => {
-      if (e.features[0].properties.description) {
+    const mouseEnterHandler = (e: MapLayerMouseEvent) => {
+      if (e.features?.[0]?.properties?.description) {
         map.getCanvas().style.cursor = "pointer";
       }
     };
@@ -347,18 +369,23 @@ export class SimpleStyle {
 
     const clusterLayer = `${this.options.id}-clusters`;
 
-    const clusterClickHandler = async (e: any) => {
+    const clusterClickHandler = async (e: MapLayerMouseEvent) => {
       const features = this.map.queryRenderedFeatures(e.point, {
         layers: [clusterLayer],
       });
-      const clusterId = features[0].properties.cluster_id;
-      const zoom = await this.map
-        .getSource(`${this.options.id}-points`)
-        .getClusterExpansionZoom(clusterId);
+      if (!features[0]) return;
+      const clusterId = features[0].properties?.cluster_id;
+      const source = this.map.getSource(
+        `${this.options.id}-points`,
+      ) as GeoJSONSource;
+      const zoom = await source.getClusterExpansionZoom(clusterId);
 
       this.map.easeTo({
-        center: features[0].geometry.coordinates,
-        zoom: zoom,
+        center: (features[0].geometry as GeoJSON.Point).coordinates as [
+          number,
+          number,
+        ],
+        zoom,
       });
     };
 
@@ -424,7 +451,7 @@ export class SimpleStyle {
     return this;
   }
 
-  setGeoJSON(geojson: string | GeoJSON.GeoJSON) {
+  setGeoJSON(geojson: string | FeatureCollection) {
     if (typeof geojson === "string" && isURL(geojson)) {
       this.geojson = template;
 
@@ -445,7 +472,7 @@ export class SimpleStyle {
       };
 
       this._loadingPromise = fetchGeoJSON();
-    } else {
+    } else if (typeof geojson !== "string") {
       this.geojson = geojson;
     }
   }

--- a/src/lib/simplestyle.ts
+++ b/src/lib/simplestyle.ts
@@ -375,6 +375,7 @@ export class SimpleStyle {
       });
       if (!features[0]) return;
       const clusterId = features[0].properties?.cluster_id;
+      if (clusterId === undefined) return;
       const source = this.map.getSource(
         `${this.options.id}-points`,
       ) as GeoJSONSource;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type GeoloniaMapOptions = MapOptions & {
   /** Geolonia logo control */
   geoloniaControl?: boolean | ControlPosition;
   /** GeoJSON URL or object for SimpleStyle */
-  geojson?: string | GeoJSON.GeoJSON;
+  geojson?: string | GeoJSON.FeatureCollection;
   /** Enable clustering for GeoJSON points */
   cluster?: boolean;
   /** Cluster marker color */


### PR DESCRIPTION
## Summary
`npm run lint` で出力される40件の警告をほぼすべて解消しました（残り1件は `vendor.d.ts` で #51 マージ時に解消）。

### 変更内容

**src/lib/controls/attribution.ts**
- non-null assertion (`!`) → optional chaining (`?.`) に置換 (5箇所)
- 未使用 private メンバー削除: `_editLink`, `styleId`, `styleOwner`（宣言と代入のみで読み取り箇所なし）
- `!this._map || !this._map.style` → `!this._map?.style` に簡略化

**src/lib/simplestyle-vector.ts**
- `map: any` → `map: MaplibreMap` (5箇所)
- `event: any` → `MapSourceDataEvent`, `e: any` → `MapLayerMouseEvent`
- `source && source.loaded()` → `source?.loaded()`
- `e.features[0]` → null guard 追加

**src/lib/simplestyle.ts**
- `any` を適切な型に置換: `MaplibreMap`, `FeatureCollection`, `MapLayerMouseEvent`, `GeoJSONSource`, `MapLayerEventType`
- `SimpleStyleOptions` インターフェース追加
- `getSource()` の戻り値を `GeoJSONSource` にキャスト
- `e.features` の null guard 追加

**src/lib/geolonia-map.ts**
- constructor return に `biome-ignore` 追加（意図的な singleton パターン）

**example/marker-popup.ts, example/options.ts**
- non-null assertion → null coalescing (`?? ""`)

**src/types.ts**
- `geojson` オプション型を `GeoJSON.GeoJSON` → `GeoJSON.FeatureCollection` に限定

## Test plan
- [x] 全131ユニットテストパス (`npm run test`)
- [x] 全38 e2eテストパス (`npm run e2e`)
- [x] `npm run lint` で警告1件（vendor.d.ts のみ、#51 で解消予定）
- [x] `npx tsc --noEmit` で maplibre-util.ts 以外のエラーなし（#66 で解消予定）

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * URLパラメーターのnull値処理を改善し、デフォルト値を使用するようにしました。
  * カスタムマーカーオプションの処理を安定化させました。

* **改善**
  * コードの堅牢性を強化し、予期しないnull参照エラーを防ぐようにしました。
  * 内部の型安全性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->