### PR TITLE
update sanitize-html for security reason, bump 0.4.1

### DIFF
--- a/e2e/external-style.spec.ts
+++ b/e2e/external-style.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { readCanvasPixelsUpperHalf, waitForMapLoad } from "./helper";
 
-const EXTERNAL_STYLE_URL =
-  "https://tile.openstreetmap.jp/styles/osm-bright/style.json";
+const EXTERNAL_STYLE_URL = "https://demotiles.maplibre.org/globe.json";
 
 test.describe("External style support", () => {
   test("should render a map with external style URL", async ({ page }) => {

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -129,7 +129,7 @@ test.describe("Constructor options", () => {
 
       const map2 = new GeoloniaMapCtor({
         container: div,
-        style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+        style: "https://demotiles.maplibre.org/globe.json",
         center: [139.7671, 35.6812],
         zoom: 10,
         navigationControl: false,

--- a/example/external-style.ts
+++ b/example/external-style.ts
@@ -2,8 +2,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "../src/assets/style.css";
 import { GeoloniaMap } from "../src/index";
 
-const EXTERNAL_STYLE_URL =
-  "https://tile.openstreetmap.jp/styles/osm-bright/style.json";
+const EXTERNAL_STYLE_URL = "https://demotiles.maplibre.org/globe.json";
 
 const map = new GeoloniaMap({
   container: "#map",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/maps-core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",
         "@turf/bbox": "^7.3.4",
         "@turf/center": "^7.3.4",
         "pmtiles": "^4.4.0",
-        "sanitize-html": "^2.17.3",
+        "sanitize-html": "^2.17.4",
         "tinycolor2": "^1.4.1"
       },
       "devDependencies": {
@@ -1862,6 +1862,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2310,6 +2316,15 @@
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "license": "ISC"
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -2846,15 +2861,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "main": "dist/npm/index.cjs",
   "module": "dist/npm/index.js",
@@ -22,7 +22,7 @@
     "@turf/bbox": "^7.3.4",
     "@turf/center": "^7.3.4",
     "pmtiles": "^4.4.0",
-    "sanitize-html": "^2.17.3",
+    "sanitize-html": "^2.17.4",
     "tinycolor2": "^1.4.1"
   },
   "peerDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30000,
+  retries: process.env.CI ? 2 : 1,
   use: {
     baseURL: "http://localhost:5174",
     launchOptions: {


### PR DESCRIPTION
## Summary

<!-- Briefly describe your changes -->
- sanitize-html がXSSの脆弱性があったので対応
- playwright configにretriesを設定
- mainブランチに追従
- 0.4.1 release
- 外部リソースを tile.openstreetmap.jpからdemotile.maplibre.orgへ変更

## Checklist (optional)

- [ ] Tests added/updated
- [ ] Docs updated

## Related Issues

close: #77

<!-- fill all issues that is related to this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * バージョンを 0.4.0 から 0.4.1 に更新
  * 依存パッケージ（sanitize-html）をマイナーバージョンアップ

* **Tests**
  * Playwright の再試行設定を追加（CI:2回、ローカル:1回）
  * E2E テストで参照する外部スタイルURLを新しい地図タイルに切替

* **Examples**
  * サンプルの外部スタイル参照を新しい地図タイルURLに更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/maps-core/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->