### PR TITLE
#80 migrate non-smoke E2E to local style fixture

### DIFF
--- a/e2e/geojson.spec.ts
+++ b/e2e/geojson.spec.ts
@@ -58,8 +58,21 @@ test.describe("GeoJSON / SimpleStyle", () => {
     await page.goto("/geojson.html?noCenter=true");
     await waitForMapLoad(page);
 
-    // Allow a little time for fitBounds to animate
-    await page.waitForTimeout(500);
+    // SimpleStyle.fitBounds() runs an animated transition (duration: 3000ms),
+    // so poll until the center has moved into the Tokyo bbox instead of
+    // relying on a fixed sleep.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const map = (window as unknown as Record<string, unknown>).map as {
+              getCenter: () => { lng: number; lat: number };
+            };
+            return map.getCenter().lng;
+          }),
+        { timeout: 5000 },
+      )
+      .toBeGreaterThan(139);
 
     const center = await page.evaluate(() => {
       const map = (window as unknown as Record<string, unknown>).map as {
@@ -69,10 +82,6 @@ test.describe("GeoJSON / SimpleStyle", () => {
       return { lng: c.lng, lat: c.lat };
     });
 
-    // Feature centroid is roughly around 139.72, 35.68 (Tokyo area).
-    // Default center in options.ts is 139.7671, 35.6812 — when unset,
-    // MapLibre defaults to [0, 0]. fitBounds should move it to Tokyo.
-    expect(center.lng).toBeGreaterThan(139);
     expect(center.lng).toBeLessThan(140);
     expect(center.lat).toBeGreaterThan(35);
     expect(center.lat).toBeLessThan(36);

--- a/e2e/loader.spec.ts
+++ b/e2e/loader.spec.ts
@@ -5,9 +5,14 @@ test.describe("Loader animation", () => {
   test("should show loader while the map is loading (default)", async ({
     page,
   }) => {
+    // Delay the style fetch so the loader is observable. With the local
+    // fixture the map otherwise finishes loading almost instantly.
+    await page.route("**/sample-basic-style.json", async (route) => {
+      await new Promise((r) => setTimeout(r, 1000));
+      await route.continue();
+    });
+
     await page.goto("/loader.html");
-    // Grab the loader before the map finishes loading. The element is
-    // created synchronously in the constructor, so it exists immediately.
     await expect(page.locator(".loading-geolonia-map")).toHaveCount(1);
   });
 

--- a/example/controls.ts
+++ b/example/controls.ts
@@ -17,7 +17,7 @@ function parseBoolOrPosition(
 
 const map = new GeoloniaMap({
   container: "#map",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   center: [139.7671, 35.6812],
   zoom: 12,
   gestureHandling: false,

--- a/example/geojson.ts
+++ b/example/geojson.ts
@@ -28,7 +28,7 @@ const inlineGeoJSON: GeoJSON.FeatureCollection = {
 
 const options: GeoloniaMapOptions = {
   container: "#map",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   zoom: 12,
   marker: false,
   gestureHandling: false,

--- a/example/gesture.ts
+++ b/example/gesture.ts
@@ -7,7 +7,7 @@ const params = new URLSearchParams(window.location.search);
 
 const options: GeoloniaMapOptions = {
   container: "#map",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   center: [139.7671, 35.6812],
   zoom: 10,
   marker: false,

--- a/example/lifecycle.ts
+++ b/example/lifecycle.ts
@@ -7,7 +7,7 @@ import { GeoloniaMap } from "../src/index";
 const map = new GeoloniaMap({
   container: "#map",
   apiKey: "YOUR-API-KEY",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   center: [139.7671, 35.6812],
   zoom: 12,
   marker: false,

--- a/example/loader.ts
+++ b/example/loader.ts
@@ -7,7 +7,7 @@ const params = new URLSearchParams(window.location.search);
 
 const options: GeoloniaMapOptions = {
   container: "#map",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   center: [139.7671, 35.6812],
   zoom: 12,
   marker: false,

--- a/example/main.ts
+++ b/example/main.ts
@@ -4,7 +4,7 @@ import { GeoloniaMap } from "../src/index";
 
 const map = new GeoloniaMap({
   container: "#map",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   center: [139.7671, 35.6812],
   zoom: 12,
   navigationControl: false,

--- a/example/marker-popup.ts
+++ b/example/marker-popup.ts
@@ -8,7 +8,7 @@ const params = new URLSearchParams(window.location.search);
 
 const options: GeoloniaMapOptions = {
   container: "#map",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   center: [139.7671, 35.6812],
   zoom: 14,
   marker: params.get("marker") !== "false",

--- a/example/multiple-maps.ts
+++ b/example/multiple-maps.ts
@@ -2,9 +2,10 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "../src/assets/style.css";
 import { GeoloniaMap } from "../src/index";
 
-const osmStyle = "https://tile.openstreetmap.jp/styles/osm-bright/style.json";
-const vtStyle =
-  "https://tile.openstreetmap.jp/styles/maptiler-toner-en/style.json";
+// Use two distinct local fixtures so the "different styles per map" assertion
+// in multiple-maps.spec.ts can compare them without external dependencies.
+const styleA = "/sample-basic-style.json";
+const styleB = "/sample-3d-style.json";
 
 const commonOptions = {
   zoom: 10,
@@ -17,14 +18,14 @@ const commonOptions = {
 
 const mapA = new GeoloniaMap({
   container: "#map-a",
-  style: osmStyle,
+  style: styleA,
   center: [139.7671, 35.6812],
   ...commonOptions,
 });
 
 const mapB = new GeoloniaMap({
   container: "#map-b",
-  style: vtStyle,
+  style: styleB,
   center: [135.5023, 34.6937],
   ...commonOptions,
 });
@@ -34,7 +35,7 @@ const mapB = new GeoloniaMap({
 // new one.
 const mapADup = new GeoloniaMap({
   container: "#map-a",
-  style: osmStyle,
+  style: styleA,
   ...commonOptions,
 });
 

--- a/example/options.ts
+++ b/example/options.ts
@@ -8,9 +8,7 @@ const params = new URLSearchParams(window.location.search);
 
 const options: GeoloniaMapOptions = {
   container: "#map",
-  style:
-    params.get("style") ||
-    "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: params.get("style") || "/sample-basic-style.json",
   center: params.has("center")
     ? JSON.parse(params.get("center") ?? "[]")
     : [139.7671, 35.6812],

--- a/example/sample-basic-style.json
+++ b/example/sample-basic-style.json
@@ -1,13 +1,24 @@
 {
   "version": 8,
-  "sources": {},
+  "glyphs": "/glyphs/{fontstack}/{range}.pbf",
+  "sources": {
+    "fixture": {
+      "type": "geojson",
+      "data": { "type": "FeatureCollection", "features": [] },
+      "attribution": "<a href=\"https://example.com\">Test fixture</a>"
+    }
+  },
   "layers": [
     {
       "id": "background",
       "type": "background",
-      "paint": {
-        "background-color": "#cccccc"
-      }
+      "paint": { "background-color": "#cccccc" }
+    },
+    {
+      "id": "fixture",
+      "type": "fill",
+      "source": "fixture",
+      "paint": { "fill-color": "#cccccc" }
     }
   ]
 }

--- a/example/sample-basic-style.json
+++ b/example/sample-basic-style.json
@@ -1,0 +1,13 @@
+{
+  "version": 8,
+  "sources": {},
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#cccccc"
+      }
+    }
+  ]
+}

--- a/example/simple-vector.ts
+++ b/example/simple-vector.ts
@@ -7,7 +7,7 @@ const params = new URLSearchParams(window.location.search);
 
 const options: GeoloniaMapOptions = {
   container: "#map",
-  style: "https://tile.openstreetmap.jp/styles/osm-bright/style.json",
+  style: "/sample-basic-style.json",
   zoom: 6,
   marker: false,
   gestureHandling: false,


### PR DESCRIPTION
Fixes #80
Closes #82 (retries approach abandoned in favor of this)

## Summary

E2E flaky 対策。`tile.openstreetmap.jp` の外部スタイルを「リアル描画 smoke」以外の全テストで使うのをやめ、ローカル fixture `example/sample-basic-style.json` に置き換え。

### 変更内容
- `example/sample-basic-style.json` 新規追加（MapLibre v8 minimal style）
  - `background` レイヤー `#cccccc`（pixel 非白テストを通す）
  - `glyphs`: ローカル 404 path（symbol layer の add が失敗しないため必須。MapLibre は glyphs 未設定だと symbol 系を silently skip する）
  - dummy `geojson` source + `attribution` field（`attribution.spec.ts` が source.attribution を集めて検証するため）
- 12 個の `example/*.ts` で style URL を local fixture に置換
- `multiple-maps.ts` のみ map-a=`sample-basic-style.json`、map-b=`sample-3d-style.json` で2種類を使い分け
- `geojson.spec.ts` の fitBounds テスト: `waitForTimeout(500)` → `expect.poll` （ローカル fixture だとロード完了が早すぎて animation 中の polling が必要に）
- `loader.spec.ts` のローダー観測テスト: style fetch を `page.route` で 1s 遅延（ローダー要素が消える前に観測するため）

### 外部依存を維持するテスト（smoke）
意図的にそのまま:
- `external-style.spec.ts` (外部 URL fetch 検証)
- `geolonia-style.spec.ts` (Geolonia CDN 検証)
- `authentication.spec.ts` (transformRequest が Geolonia URL に key/sessionId を付ける挙動)
- `lifecycle.spec.ts` の setStyle URL/CDN 解決アサーション
- `3d.ts` は既に `sample-3d-style.json` を使用

### 効果
- 全 60 テスト pass
- 実行時間: 約3分 → **約34秒**
- ローカルで **3回連続 全件 pass** 確認（flaky 解消）

## レビュー観点

専門家レビュー依頼ポイント:

- [ ] **fixture の minimal style 仕様**: MapLibre v5 で必要十分か（特に `glyphs` を `/glyphs/{fontstack}/{range}.pbf`（404 する path）にしている点）
- [ ] **attribution 取得用の dummy source**: 空 GeoJSON + fill layer で `attribution` 値を style.sourceCaches 経由で拾わせる設計の妥当性
- [ ] **multiple-maps での 3d fixture 流用**: map-b に `sample-3d-style.json`（3D testing 用 fixture）を使い回している点

## Test plan
- [x] `npm run test`（ユニット 131件）
- [x] `npm run lint`（エラーなし）
- [x] `npm run e2e`（60件 / 34秒）
- [x] ローカル 3回連続 全件 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * サンプルの基本スタイル定義ファイルを追加し、背景色などを含むベーススタイル設定テンプレートを提供します。
* **Tests**
  * GeoJSON 関連テストで固定待機を廃止し、フィットアニメーション完了をポーリングで検証するように改善しました。
  * ローダー表示テストでスタイル読み込みを遅延させ、ローダーが確実に観測できるようにしました。
* **Chores**
  * サンプル例が外部スタイル参照から追加のローカルスタイル定義を利用するように切替えました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/maps-core/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->