### PR TITLE
#82 retry flaky e2e tests on CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30000,
+  // Retry flaky tests on CI. Local runs keep retries off so debugging stays
+  // honest. This is a stopgap; the real fix is replacing external style
+  // dependencies with a local fixture (see #80).
+  retries: process.env.CI ? 2 : 0,
   use: {
     baseURL: "http://localhost:5174",
     launchOptions: {


### PR DESCRIPTION
Fixes #82

## Summary
`playwright.config.ts` に `retries: process.env.CI ? 2 : 0` を追加。CI 上での flaky な失敗を retry で吸収して PR の merge を可能にする。ローカルでは 0 のままなので開発時のデバッグ体験は変わらない。

```ts
retries: process.env.CI ? 2 : 0,
```

## Why
E2E が外部 style (`tile.openstreetmap.jp` / `cdn.geolonia.com`) に依存するため flaky 化している。根本対処（ローカル style fixture 化、#80）は別 PR で進めるが、それを merge するためにも先に CI を通せる状態を作る必要がある。

## Scope
これは **暫定対応**。fixture 置換が完了したら retries は撤去する想定。

## Test plan
- [x] ローカル `npm run e2e` は変わらず動く（retries 0）
- [ ] CI で flaky テストが retry で救済されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * CI環境でのテスト失敗時に自動リトライを有効化し、テスト安定性を向上させました。ローカル環境の動作に変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/maps-core/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->