### PR TITLE
test(e2e): dev 環境 (api.geolonia.com/dev) の検証を追加

### DIFF
--- a/e2e/dev-environment.spec.ts
+++ b/e2e/dev-environment.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+import {
+  collectConsoleErrors,
+  readCanvasPixelsUpperHalf,
+  waitForMapLoad,
+} from "./helper";
+
+// dev 環境 (api.geolonia.com/dev) を明示的に検証する e2e。
+//
+// stage=dev で地図をロードすると、SDK は dev ステージのエンドポイントを叩く (geolonia-map.ts)。
+// geolonia/basic-v2 では sprite が `https://api.geolonia.com/${stage}/sprites/...` に解決されるため、
+// dev の sprite が 2xx を返し、その上で地図が描画されることを確認する。
+// dev バックエンドに変更が入った際の疎通・描画の回帰ネットとして使う。
+test.describe("dev environment (api.geolonia.com/dev)", () => {
+  test.beforeEach(async ({ page }) => {
+    // glyph は dev サーバへ寄せる (本番の CORS 未対応回避。geolonia-style.spec と同様)。
+    await page.route("**/glyphs.geolonia.com/**", (route) => {
+      const url = route
+        .request()
+        .url()
+        .replace("glyphs.geolonia.com", "glyphs-dev.geolonia.com");
+      route.continue({ url });
+    });
+  });
+
+  test("requests the dev backend (api.geolonia.com/dev)", async ({ page }) => {
+    // stage=dev のとき SDK が api.geolonia.com の dev ステージを叩くことを確認する。
+    // basic-v2 では sprite が api.geolonia.com/dev/sprites/... に解決される。
+    const devRequests: string[] = [];
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes("api.geolonia.com/dev/")) {
+        devRequests.push(url.split("?")[0]);
+      }
+    });
+    await page.goto("/geolonia-style.html?stage=dev");
+    await waitForMapLoad(page);
+    // 地図ロード後に残りのアセット (sprite 等) 取得を少し待つ
+    await page.waitForTimeout(2000);
+    expect(devRequests.length).toBeGreaterThan(0);
+  });
+
+  test("renders a map backed by the dev environment", async ({ page }) => {
+    const errors = collectConsoleErrors(page);
+    await page.goto("/geolonia-style.html?stage=dev");
+    await waitForMapLoad(page);
+    const hasContent = await readCanvasPixelsUpperHalf(page);
+    expect(hasContent).toBe(true);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/e2e/dev-environment.spec.ts
+++ b/e2e/dev-environment.spec.ts
@@ -23,21 +23,24 @@ test.describe("dev environment (api.geolonia.com/dev)", () => {
     });
   });
 
-  test("requests the dev backend (api.geolonia.com/dev)", async ({ page }) => {
-    // stage=dev のとき SDK が api.geolonia.com の dev ステージを叩くことを確認する。
-    // basic-v2 では sprite が api.geolonia.com/dev/sprites/... に解決される。
-    const devRequests: string[] = [];
+  test("requests dev sprites (api.geolonia.com/dev/sprites)", async ({
+    page,
+  }) => {
+    // stage=dev のとき SDK が sprite を api.geolonia.com/dev/sprites/... に解決して
+    // 叩くことを確認する (sprite の stage 書き換えの回帰検知)。
+    const devSpriteRequests: string[] = [];
     page.on("request", (req) => {
       const url = req.url();
-      if (url.includes("api.geolonia.com/dev/")) {
-        devRequests.push(url.split("?")[0]);
+      if (url.includes("api.geolonia.com/dev/sprites/")) {
+        devSpriteRequests.push(url.split("?")[0]);
       }
     });
     await page.goto("/geolonia-style.html?stage=dev");
     await waitForMapLoad(page);
-    // 地図ロード後に残りのアセット (sprite 等) 取得を少し待つ
-    await page.waitForTimeout(2000);
-    expect(devRequests.length).toBeGreaterThan(0);
+    // 固定 sleep ではなく観測条件を待つ (CI 安定性のため)
+    await expect
+      .poll(() => devSpriteRequests.length, { timeout: 10_000 })
+      .toBeGreaterThan(0);
   });
 
   test("renders a map backed by the dev environment", async ({ page }) => {


### PR DESCRIPTION
## 概要

`stage=dev` で地図をロードした際に、SDK が dev ステージのエンドポイント（`api.geolonia.com/dev`）を叩き、地図が正しく描画されることを検証する Playwright e2e を追加します。dev バックエンドに変更が入った際の回帰ネットになります。

## 追加テスト（`e2e/dev-environment.spec.ts`）

- **requests the dev backend (api.geolonia.com/dev)**: `stage=dev` で `api.geolonia.com/dev` へのリクエストが発生することを確認（`geolonia/basic-v2` では sprite が `api.geolonia.com/dev/sprites/...` に解決される）
- **renders a map backed by the dev environment**: canvas ロード + タイル描画 + アプリレベルのコンソールエラーが無いことを確認

既存の `geolonia-style.spec.ts` と同じヘルパー（`waitForMapLoad` / `readCanvasPixelsUpperHalf` / `collectConsoleErrors`）とパターンを踏襲しています。

## テスト

- `npm run e2e`（ローカルは事前に `npm ci` で依存を最新化しておく）
- ローカルで2回連続の安定 pass を確認
- CI（`ci.yml` の e2e ジョブ）でも実行されます

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 開発環境での通信と地図描画機能の正常動作を検証するエンドツーエンドテストを新規追加しました。通信の疎通確認、地図描画の正常性確認、エラーがないことを自動的に検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->