### PR TITLE
feat: 後方互換 — GeoloniaMap コンストラクタで文字列/要素を受け付ける (#90)

### DIFF
--- a/e2e/legacy-constructor.spec.ts
+++ b/e2e/legacy-constructor.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { waitForMapLoad } from "./helper";
+
+/**
+ * Backward compatibility with the old embed API: `new geolonia.Map('#map')`
+ * and `new geolonia.Map(element)` resolve the container and read its `data-*`
+ * attributes into the map options. See maps-core#90 / embed#500.
+ */
+test.describe("Legacy constructor argument", () => {
+  const readState = (page: import("@playwright/test").Page) =>
+    page.evaluate(() => {
+      const map = (window as unknown as Record<string, unknown>).map as {
+        getCenter: () => { lng: number; lat: number };
+        getZoom: () => number;
+        getMinZoom: () => number;
+        getMaxZoom: () => number;
+      };
+      const c = map.getCenter();
+      return {
+        lng: c.lng,
+        lat: c.lat,
+        zoom: map.getZoom(),
+        minZoom: map.getMinZoom(),
+        maxZoom: map.getMaxZoom(),
+      };
+    });
+
+  test("CSS selector string reads data-* attributes", async ({ page }) => {
+    await page.goto("/legacy-constructor.html");
+    await waitForMapLoad(page);
+
+    const state = await readState(page);
+    expect(state.lng).toBeCloseTo(135.5, 1);
+    expect(state.lat).toBeCloseTo(34.7, 1);
+    expect(state.zoom).toBeCloseTo(10, 0);
+    expect(state.minZoom).toBe(5);
+    expect(state.maxZoom).toBe(15);
+  });
+
+  test("HTMLElement argument reads data-* attributes", async ({ page }) => {
+    await page.goto("/legacy-constructor.html?arg=element");
+    await waitForMapLoad(page);
+
+    const state = await readState(page);
+    expect(state.lng).toBeCloseTo(135.5, 1);
+    expect(state.lat).toBeCloseTo(34.7, 1);
+    expect(state.zoom).toBeCloseTo(10, 0);
+  });
+});

--- a/example/legacy-constructor.html
+++ b/example/legacy-constructor.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Legacy Constructor E2E</title>
+  <style>
+    #map { width: 100%; height: 400px; }
+  </style>
+</head>
+<body>
+  <!-- Old embed API: bare container + data-* attributes, no options object. -->
+  <div
+    id="map"
+    class="geolonia"
+    data-style="/sample-basic-style.json"
+    data-lat="34.7"
+    data-lng="135.5"
+    data-zoom="10"
+    data-min-zoom="5"
+    data-max-zoom="15"
+    data-navigation-control="off"
+    data-geolonia-control="off"
+    data-gesture-handling="off"
+    data-loader="off"
+    data-marker="off"
+  ></div>
+  <script type="module" src="/legacy-constructor.ts"></script>
+</body>
+</html>

--- a/example/legacy-constructor.ts
+++ b/example/legacy-constructor.ts
@@ -1,0 +1,16 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import { GeoloniaMap } from "../src/index";
+
+// Legacy embed API: pass a bare CSS selector string. The container's `data-*`
+// attributes are read into the map options (center, zoom, controls, ...).
+const params = new URLSearchParams(window.location.search);
+const arg = params.get("arg");
+
+// `arg=element` exercises the HTMLElement form; anything else uses the selector.
+const map =
+  arg === "element"
+    ? new GeoloniaMap(document.getElementById("map") as HTMLElement)
+    : new GeoloniaMap("#map");
+
+(window as unknown as Record<string, unknown>).map = map;

--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -29,6 +29,7 @@ function ensurePMTiles(): void {
 
 import type { GeoloniaMapOptions } from "../types";
 import { keyring } from "./keyring";
+import { normalizeConstructorArg } from "./legacy-options";
 import {
   type GetImageCallback,
   getLang,
@@ -48,14 +49,22 @@ type Container = HTMLElement & {
 
 /**
  * Geolonia Map - extends MapLibre GL Map with Geolonia-specific features.
- * Accepts a GeoloniaMapOptions object directly (no DOM attribute parsing).
+ *
+ * Accepts a {@link GeoloniaMapOptions} object, or — for backward compatibility
+ * with the old embed API — a CSS selector string or an HTMLElement, in which
+ * case the container's `data-*` attributes are read into options.
  */
 export default class GeoloniaMap extends maplibregl.Map {
   private geoloniaSourcesUrl!: URL;
   private __styleExtensionLoadRequired!: boolean;
 
   // biome-ignore lint/correctness/noUnreachableSuper: intentional singleton pattern - returns existing map instance before super()
-  constructor(options: GeoloniaMapOptions) {
+  constructor(arg: string | HTMLElement | GeoloniaMapOptions) {
+    // Backward compatibility: accept a bare container (CSS selector string or
+    // HTMLElement) like the old embed API. In that legacy form the container's
+    // `data-*` attributes are read into options; the object form is unchanged.
+    const options = normalizeConstructorArg(arg);
+
     // Register PMTiles protocol on first map creation
     ensurePMTiles();
 

--- a/src/lib/legacy-options.ts
+++ b/src/lib/legacy-options.ts
@@ -1,0 +1,156 @@
+import type { ControlPosition } from "maplibre-gl";
+import type { GeoloniaMapOptions } from "../types";
+
+/**
+ * Backward-compatibility layer for the old embed API, where the map was created
+ * from a bare container (`new geolonia.Map('#map')` or an HTMLElement) and its
+ * `data-*` attributes configured the map. Mirrors embed's attsToOptions() so
+ * the legacy calling convention keeps the same defaults and behavior.
+ */
+
+const CONTROL_POSITIONS = [
+  "top-right",
+  "bottom-right",
+  "bottom-left",
+  "top-left",
+] as const;
+
+/** Convert a `data-*-control` value (`on`/`off`/position) to `boolean | ControlPosition`. */
+function toControlAttr(value: string): boolean | ControlPosition {
+  const v = value.toLowerCase();
+  if ((CONTROL_POSITIONS as readonly string[]).includes(v)) {
+    return v as ControlPosition;
+  }
+  return v === "on";
+}
+
+/** True when `value` is a CSS selector for an inline element, not a URL/path. */
+function isCssSelector(value: string): Element | null {
+  if (/^https?:\/\//.test(value) || /^\.?\.?\//.test(value)) {
+    return null;
+  }
+  try {
+    return document.querySelector(value);
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve a `data-geojson` value to a URL/JSON string or parsed FeatureCollection. */
+function resolveGeojson(value: string): string | GeoJSON.FeatureCollection {
+  const el = isCssSelector(value);
+  if (el?.textContent) {
+    return JSON.parse(el.textContent) as GeoJSON.FeatureCollection;
+  }
+  return value;
+}
+
+/** Detect a DOM element without assuming HTMLElement is defined (SSR-safe). */
+export function isDomElement(o: unknown): o is HTMLElement {
+  return typeof HTMLElement !== "undefined"
+    ? o instanceof HTMLElement
+    : !!o &&
+        typeof o === "object" &&
+        (o as { nodeType?: number }).nodeType === 1;
+}
+
+/**
+ * Read a container's `data-*` attributes into GeoloniaMapOptions, reproducing
+ * the legacy embed behavior of `new geolonia.Map('#map')`. Only keys that were
+ * meaningful in the old embed are read; the same defaults apply (marker on,
+ * loader on, navigation/geolonia control on, etc.).
+ */
+export function optionsFromContainer(
+  container: HTMLElement,
+): GeoloniaMapOptions {
+  const ds = container.dataset;
+  const options: GeoloniaMapOptions = {
+    container,
+    bearing: Number.parseFloat(ds.bearing ?? "") || 0,
+    pitch: Number.parseFloat(ds.pitch ?? "") || 0,
+    zoom: Number.parseFloat(ds.zoom ?? "") || 0,
+    hash: ds.hash === "on",
+    marker: (ds.marker ?? "on") === "on",
+    markerColor: ds.markerColor ?? "#E4402F",
+    openPopup: ds.openPopup === "on",
+    loader: ds.loader !== "off",
+    gestureHandling: ds.gestureHandling !== "off",
+    navigationControl: toControlAttr(ds.navigationControl ?? "on"),
+    geolocateControl: toControlAttr(ds.geolocateControl ?? "off"),
+    fullscreenControl: toControlAttr(ds.fullscreenControl ?? "off"),
+    scaleControl: toControlAttr(ds.scaleControl ?? "off"),
+    geoloniaControl: toControlAttr(ds.geoloniaControl ?? "on"),
+    cluster: (ds.cluster ?? "on") === "on",
+    clusterColor: ds.clusterColor ?? "#ff0000",
+    "3d": ds["3d"] === "on",
+  };
+
+  if (ds.style) options.style = ds.style;
+  if (ds.lang !== undefined) {
+    options.lang = ds.lang as GeoloniaMapOptions["lang"];
+  }
+  if (ds.key) options.apiKey = ds.key;
+  if (ds.stage) options.stage = ds.stage;
+
+  // Set center only when both lat and lng are present (mirrors embed gating:
+  // marker requires a center, and GeoJSON fitBounds is skipped when one is set).
+  const hasLat = ds.lat !== undefined && ds.lat !== "";
+  const hasLng = ds.lng !== undefined && ds.lng !== "";
+  if (hasLat && hasLng) {
+    options.center = [
+      Number.parseFloat(ds.lng as string),
+      Number.parseFloat(ds.lat as string),
+    ];
+  }
+
+  if (ds.customMarker) options.customMarker = ds.customMarker;
+  if (ds.customMarkerOffset) {
+    const [x, y] = ds.customMarkerOffset
+      .split(",")
+      .map((n) => Number(n.trim()));
+    options.customMarkerOffset = [x || 0, y || 0];
+  }
+  if (ds.geojson) options.geojson = resolveGeojson(ds.geojson);
+  if (ds.simpleVector) options.simpleVector = ds.simpleVector;
+
+  if (
+    ds.minZoom !== undefined &&
+    ds.minZoom !== "" &&
+    (Number(ds.minZoom) === 0 || Number(ds.minZoom))
+  ) {
+    options.minZoom = Number(ds.minZoom);
+  }
+  if (
+    ds.maxZoom !== undefined &&
+    ds.maxZoom !== "" &&
+    (Number(ds.maxZoom) === 0 || Number(ds.maxZoom))
+  ) {
+    options.maxZoom = Number(ds.maxZoom);
+  }
+
+  return options;
+}
+
+/**
+ * Normalize a constructor argument into GeoloniaMapOptions. Accepts the legacy
+ * embed forms — a CSS selector string or an HTMLElement — in addition to the
+ * options object. Legacy forms read the container's `data-*` attributes; the
+ * options object is passed through unchanged.
+ */
+export function normalizeConstructorArg(
+  arg: string | HTMLElement | GeoloniaMapOptions,
+): GeoloniaMapOptions {
+  if (typeof arg === "string") {
+    const el = document.querySelector(arg) || document.getElementById(arg);
+    if (!el) {
+      throw new Error(
+        `[Geolonia] No HTML elements found matching \`${arg}\`. Please ensure the map container element exists.`,
+      );
+    }
+    return optionsFromContainer(el as HTMLElement);
+  }
+  if (isDomElement(arg)) {
+    return optionsFromContainer(arg);
+  }
+  return arg;
+}

--- a/test/legacy-options.test.ts
+++ b/test/legacy-options.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import {
+  normalizeConstructorArg,
+  optionsFromContainer,
+} from "../src/lib/legacy-options";
+
+/**
+ * Backward compatibility for the old embed API (maps-core#90): a bare container
+ * (CSS selector or HTMLElement) is resolved and its `data-*` attributes are
+ * read into GeoloniaMapOptions, mirroring embed's attsToOptions() defaults.
+ */
+describe("optionsFromContainer", () => {
+  it("applies old-embed defaults for an attribute-less container", () => {
+    const el = document.createElement("div");
+    const opts = optionsFromContainer(el);
+
+    expect(opts.container).toBe(el);
+    expect(opts.marker).toBe(true);
+    expect(opts.markerColor).toBe("#E4402F");
+    expect(opts.loader).toBe(true);
+    expect(opts.gestureHandling).toBe(true);
+    expect(opts.navigationControl).toBe(true);
+    expect(opts.geoloniaControl).toBe(true);
+    expect(opts.geolocateControl).toBe(false);
+    expect(opts.fullscreenControl).toBe(false);
+    expect(opts.scaleControl).toBe(false);
+    expect(opts.cluster).toBe(true);
+    expect(opts.hash).toBe(false);
+    expect(opts["3d"]).toBe(false);
+    // No coordinates → no center (keeps marker gating / geojson fitBounds).
+    expect(opts.center).toBeUndefined();
+  });
+
+  it("reads data-* attributes into options", () => {
+    const el = document.createElement("div");
+    el.dataset.lat = "34.7";
+    el.dataset.lng = "135.5";
+    el.dataset.zoom = "10";
+    el.dataset.marker = "off";
+    el.dataset.hash = "on";
+    el.dataset.style = "geolonia/gsi";
+    el.dataset.lang = "en";
+
+    const opts = optionsFromContainer(el);
+
+    expect(opts.center).toEqual([135.5, 34.7]);
+    expect(opts.zoom).toBe(10);
+    expect(opts.marker).toBe(false);
+    expect(opts.hash).toBe(true);
+    expect(opts.style).toBe("geolonia/gsi");
+    expect(opts.lang).toBe("en");
+  });
+
+  it("maps control positions and on/off to boolean | ControlPosition", () => {
+    const el = document.createElement("div");
+    el.dataset.navigationControl = "top-right";
+    el.dataset.geolocateControl = "on";
+    el.dataset.scaleControl = "off";
+
+    const opts = optionsFromContainer(el);
+
+    expect(opts.navigationControl).toBe("top-right");
+    expect(opts.geolocateControl).toBe(true);
+    expect(opts.scaleControl).toBe(false);
+  });
+
+  it("sets center only when both lat and lng are present", () => {
+    const onlyLat = document.createElement("div");
+    onlyLat.dataset.lat = "35";
+    expect(optionsFromContainer(onlyLat).center).toBeUndefined();
+  });
+
+  it('honours data-max-zoom="0" (0 is a valid bound, not falsy)', () => {
+    const el = document.createElement("div");
+    el.dataset.minZoom = "0";
+    el.dataset.maxZoom = "0";
+
+    const opts = optionsFromContainer(el);
+
+    expect(opts.minZoom).toBe(0);
+    expect(opts.maxZoom).toBe(0);
+  });
+
+  it("parses customMarkerOffset into a numeric tuple", () => {
+    const el = document.createElement("div");
+    el.dataset.customMarkerOffset = "10, -5";
+    expect(optionsFromContainer(el).customMarkerOffset).toEqual([10, -5]);
+  });
+});
+
+describe("normalizeConstructorArg", () => {
+  it("resolves a CSS selector string to its container's options", () => {
+    const el = document.createElement("div");
+    el.id = "map";
+    el.dataset.zoom = "8";
+    document.body.appendChild(el);
+
+    const opts = normalizeConstructorArg("#map");
+    expect(opts.container).toBe(el);
+    expect(opts.zoom).toBe(8);
+
+    el.remove();
+  });
+
+  it("resolves a bare element id (getElementById fallback)", () => {
+    const el = document.createElement("div");
+    el.id = "map2";
+    document.body.appendChild(el);
+
+    expect(normalizeConstructorArg("map2").container).toBe(el);
+
+    el.remove();
+  });
+
+  it("reads data-* off an HTMLElement argument", () => {
+    const el = document.createElement("div");
+    el.dataset.zoom = "9";
+    expect(normalizeConstructorArg(el).zoom).toBe(9);
+  });
+
+  it("passes an options object through unchanged (no data-* parsing)", () => {
+    const el = document.createElement("div");
+    el.dataset.zoom = "9";
+    const options = { container: el, zoom: 3 };
+    // Object form must NOT re-read data-* — embed already built the options.
+    expect(normalizeConstructorArg(options)).toBe(options);
+    expect(normalizeConstructorArg(options).zoom).toBe(3);
+  });
+
+  it("throws a helpful error when the selector matches nothing", () => {
+    expect(() => normalizeConstructorArg("#does-not-exist")).toThrow(
+      /No HTML elements found matching/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

旧 embed API との後方互換を復元します。`GeoloniaMap` コンストラクタが `GeoloniaMapOptions` オブジェクトに加え、**CSS セレクタ文字列**と **HTMLElement** を再び受け付けるようにしました。#90 の対応。

```js
// いずれも動く
new GeoloniaMap({ container: "#map", zoom: 10 }); // 従来の options 形式（変更なし）
new GeoloniaMap("#map");                           // legacy: セレクタ文字列
new GeoloniaMap(document.getElementById("map"));   // legacy: HTMLElement
```

legacy 形式（文字列/要素）で渡した場合のみ、コンテナの `data-*` 属性を options に読み込みます（旧 embed の `new geolonia.Map('#map')` の挙動を再現）。

## 変更点

- **`src/lib/legacy-options.ts`（新規）** — `optionsFromContainer()` / `normalizeConstructorArg()`。embed の `attsToOptions()` を忠実に移植：
  - marker デフォルト on / loader on / navigation・geolonia control on などの旧 embed デフォルト
  - control 値（`on`/`off`/位置文字列）→ `boolean | ControlPosition`
  - `data-lat` と `data-lng` の**両方**が揃ったときだけ `center` を設定（marker gating / GeoJSON fitBounds を壊さない）
  - `data-min-zoom` / `data-max-zoom` は `0` も有効値として扱う
  - `data-geojson` の CSS セレクタ参照 → FeatureCollection 解決
- **`geolonia-map.ts`** — コンストラクタ冒頭で `normalizeConstructorArg(arg)` により引数を正規化するのみ
- **責務分離**：**options オブジェクト形式は完全に素通し**（data-* を読まない）。embed の render パスはフル options を組んで渡すため、二重パース等の影響なし。
- ja-jp の言語解決は元々の挙動のまま（lang を透過するだけ、本 PR では対象外）

## Breaking changes

なし（受け付ける引数を**増やす**変更。既存の options オブジェクト形式は完全に後方互換）。

## Test plan

- [x] `npm run lint`（biome, 全79ファイル）— clean
- [x] `npm test`（vitest）— 142 passed（うち新規 `test/legacy-options.test.ts` 11件：デフォルト値・control 位置・center gating・maxZoom=0・object 素通し・セレクタ解決/エラー）
- [x] `npm run build`（tsup）— 成功、生成 d.ts の署名が `constructor(arg: string | HTMLElement | GeoloniaMapOptions)`
- [x] `npm run e2e`（Playwright）— options / map / multiple-maps / 新規 legacy-constructor 計17件 pass（object 形式・legacy 形式の両方）

## Note

- リリース（バージョン bump）は未実施。publish 後、embed 側は **コード変更不要**（`GeoloniaMap` を re-export しているだけなので、dep を上げれば `new geolonia.Map('#map')` が復活）。
- 関連: geolonia/embed#500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 旧来の地図初期化方法に対応し、CSSセレクタや要素を指定して地図を作成できるようになりました。
  * `data-*` 属性から地図設定を読み取る既存ページ向けの互換性が追加されました。
* **Tests**
  * 旧来の初期化方法と設定読み取りの動作を確認するテストが追加されました。
  * 主要な表示設定、ズーム範囲、座標の反映が検証されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->