### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/maps-core",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/npm/index.cjs",
   "module": "dist/npm/index.js",


### PR DESCRIPTION
## 概要

バージョンを 0.4.1 → 0.4.2 に更新します。

PR #91（legacy-constructor 関連）のマージを反映したリリースバージョンです。

## 変更内容

- `package.json` / `package-lock.json` の version を 0.4.2 に更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * アプリケーションのバージョンを **0.4.2** に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->