### PR TITLE
fix: avoid named imports of maplibre-gl runtime values (#93)

### DIFF
--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -1,11 +1,6 @@
 import maplibregl, {
   type ControlPosition,
-  FullscreenControl,
-  GeolocateControl,
   type GetResourceResponse,
-  NavigationControl,
-  Popup,
-  ScaleControl,
   type StyleOptions,
   type StyleSpecification,
   type StyleSwapOptions,
@@ -246,27 +241,33 @@ export default class GeoloniaMap extends maplibregl.Map {
     const fullscreen = parseControlOption(options.fullscreenControl ?? false);
     if (fullscreen.enabled) {
       this.addControl(
-        new FullscreenControl(),
+        new maplibregl.FullscreenControl(),
         fullscreen.position as ControlPosition,
       );
     }
 
     const nav = parseControlOption(options.navigationControl ?? true);
     if (nav.enabled) {
-      this.addControl(new NavigationControl(), nav.position as ControlPosition);
+      this.addControl(
+        new maplibregl.NavigationControl(),
+        nav.position as ControlPosition,
+      );
     }
 
     const geolocate = parseControlOption(options.geolocateControl ?? false);
     if (geolocate.enabled) {
       this.addControl(
-        new GeolocateControl({}),
+        new maplibregl.GeolocateControl({}),
         geolocate.position as ControlPosition,
       );
     }
 
     const scale = parseControlOption(options.scaleControl ?? false);
     if (scale.enabled) {
-      this.addControl(new ScaleControl({}), scale.position as ControlPosition);
+      this.addControl(
+        new maplibregl.ScaleControl({}),
+        scale.position as ControlPosition,
+      );
     }
 
     // On load
@@ -335,7 +336,9 @@ export default class GeoloniaMap extends maplibregl.Map {
         // Popup from container's inner HTML content
         const content = container.dataset?.popupContent;
         if (content) {
-          const popup = new Popup({ offset: [0, -25] }).setHTML(content);
+          const popup = new maplibregl.Popup({ offset: [0, -25] }).setHTML(
+            content,
+          );
           marker.setPopup(popup);
           if (options.openPopup) {
             marker.togglePopup();

--- a/src/lib/maplibre-util.ts
+++ b/src/lib/maplibre-util.ts
@@ -1,4 +1,4 @@
-import { Point } from "maplibre-gl";
+import maplibregl, { type Point } from "maplibre-gl";
 
 /**
  * DOM utility class extracted from maplibre-gl-js.
@@ -96,23 +96,20 @@ export class DOM {
     }
   }
 
-  static mousePos(el: HTMLElement, e: MouseEvent): InstanceType<typeof Point> {
+  static mousePos(el: HTMLElement, e: MouseEvent): Point {
     const rect = el.getBoundingClientRect();
-    return new Point(
+    return new maplibregl.Point(
       e.clientX - rect.left - el.clientLeft,
       e.clientY - rect.top - el.clientTop,
     );
   }
 
-  static touchPos(
-    el: HTMLElement,
-    touches: TouchList,
-  ): InstanceType<typeof Point>[] {
+  static touchPos(el: HTMLElement, touches: TouchList): Point[] {
     const rect = el.getBoundingClientRect();
-    const points: InstanceType<typeof Point>[] = [];
+    const points: Point[] = [];
     for (let i = 0; i < touches.length; i++) {
       points.push(
-        new Point(
+        new maplibregl.Point(
           touches[i].clientX - rect.left - el.clientLeft,
           touches[i].clientY - rect.top - el.clientTop,
         ),


### PR DESCRIPTION
## 概要

maplibre-gl から**実行時の値**を名前付きインポートしている箇所を、デフォルトインポート＋プロパティアクセス（`maplibregl.X`）に統一します。

maplibre-gl v5 は `dist/maplibre-gl.js`（UMDバンドル・名前付きESMエクスポート無し）を `main` にしつつ `package.json` に `"type": "module"` を持つため、名前付きインポートは本番/ネイティブESMで解決できず、以下のエラーで落ちます。

```
The requested module 'maplibre-gl' does not provide an export named 'FullscreenControl'
```

- 開発時（Vite dev）はesbuild事前バンドルのinteropで動くが、本番ESMで失敗する（＝「開発では動くのに公開版で落ちる」の正体）

## 変更点

- `src/lib/geolonia-map.ts`: `FullscreenControl` / `GeolocateControl` / `NavigationControl` / `Popup` / `ScaleControl` を `maplibregl.X` に変更
- `src/lib/maplibre-util.ts`: `Point` を `type` インポート＋`new maplibregl.Point(...)` に変更

いずれも挙動は不変（インポート形式の変更のみ）。`maps-react` は元々この形式で正しく、本修正で足並みが揃います。

## 影響

- 本修正の再公開で **`@geolonia/maps-react` と `@geolonia/maps-suite`（npm ESM ビルド）が同時に解決**します。
- `@geolonia/maps-suite` の CDN(IIFE) ビルドと `@geolonia/embed` は元々非影響（自己完結バンドルのため）。

## 確認

- [x] `npm run build`（ESM/CJS/d.ts）成功
- [x] `npm run lint`（biome）クリーン
- [x] `npm test`（vitest）131 passed
- [x] ビルド済み ESM (`dist/npm/index.js`) から maplibre-gl の値の名前付きインポートが消滅していることを確認

Closes #93


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 地図上の全画面表示、ナビゲーション、現在地、縮尺コントロールの動作を安定化しました。
  - マーカークリック時に表示されるポップアップの生成を見直し、表示の一貫性を向上しました。
  - マウス／タッチ操作での地図上位置取得を整理し、型の扱いを統一して互換性と安定性を高めました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->