### PR TITLE
ci: add native-ESM smoke test and external-import guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - run: npm run build
+      - run: npm run check:externals
+      - run: npm run smoke
       - run: npm run build:umd
       - name: Upload build artifact
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   "scripts": {
     "build": "tsup",
     "build:umd": "vite build --config vite.umd.config.ts",
+    "check:externals": "node scripts/check-externals.mjs",
+    "smoke": "node scripts/smoke.mjs",
+    "verify": "npm run build && npm run check:externals && npm run smoke",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/check-externals.mjs
+++ b/scripts/check-externals.mjs
@@ -1,0 +1,44 @@
+// Guard: every bare import in the built dist must be declared in
+// package.json (dependencies / peerDependencies / optionalDependencies).
+import { readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url)));
+const declared = new Set([
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+  ...Object.keys(pkg.optionalDependencies ?? {}),
+]);
+const builtins = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
+
+const files = ["../dist/npm/index.js", "../dist/npm/index.cjs"];
+const re = /(?:from|require\()\s*["']([^"'][^"']*)["']/g;
+
+const toPkgName = (spec) =>
+  spec.startsWith("@") ? spec.split("/").slice(0, 2).join("/") : spec.split("/")[0];
+
+const validSpec = /^(?:@[a-z0-9._-]+\/)?[a-z0-9._-]+(?:\/[a-z0-9._-]+)*$/;
+
+const missing = new Set();
+const seen = new Set();
+for (const f of files) {
+  const src = readFileSync(new URL(f, import.meta.url), "utf8");
+  for (const [, spec] of src.matchAll(re)) {
+    if (spec.startsWith(".") || spec.startsWith("node:")) continue;
+    if (!validSpec.test(spec)) continue;
+    const name = toPkgName(spec);
+    if (builtins.has(name)) continue;
+    seen.add(name);
+    if (!declared.has(name)) missing.add(name);
+  }
+}
+
+console.log("imported bare packages:", [...seen].sort().join(", "));
+if (missing.size) {
+  console.error(
+    `\n✗ imported but NOT declared in package.json: ${[...missing].sort().join(", ")}`,
+  );
+  console.error("  → add them to dependencies or peerDependencies.");
+  process.exit(1);
+}
+console.log("✓ all imported packages are declared");

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,25 @@
+// Runtime smoke: import the BUILT dist as native ESM (the path that
+// dev/E2E via a bundler hides) and verify that all public exports exist.
+// Catches named-export breakage from deps (e.g. maplibre-gl).
+const m = await import(new URL("../dist/npm/index.js", import.meta.url));
+
+const requiredClasses = ["GeoloniaMap", "GeoloniaMarker", "CustomAttributionControl", "GeoloniaControl", "SimpleStyle", "SimpleStyleVector"];
+const requiredFunctions = ["getLang", "getStyle", "isGeoloniaTilesHost"];
+const requiredValues = ["keyring", "coreVersion"];
+
+const missing = [];
+for (const name of requiredClasses) {
+  if (typeof m[name] !== "function") missing.push(`${name} (expected function, got ${typeof m[name]})`);
+}
+for (const name of requiredFunctions) {
+  if (typeof m[name] !== "function") missing.push(`${name} (expected function, got ${typeof m[name]})`);
+}
+for (const name of requiredValues) {
+  if (typeof m[name] === "undefined") missing.push(`${name} (undefined)`);
+}
+
+if (missing.length) {
+  console.error(`✗ export problems:\n  ${missing.join("\n  ")}`);
+  process.exit(1);
+}
+console.log(`✓ native-ESM import OK — ${requiredClasses.length + requiredFunctions.length + requiredValues.length} exports verified`);


### PR DESCRIPTION
## Summary
- geolonia/maps-react#62 と同じガードを maps-core にも導入
- `scripts/check-externals.mjs` — ビルド済み dist 内の bare import がすべて package.json に宣言されているか検証する静的チェック
- `scripts/smoke.mjs` — ビルド済み dist をネイティブ ESM として import し、11 個の公開エクスポートの存在と型を検証するランタイムスモーク
- CI の `npm run build` 直後に両スクリプトを実行

## Test plan
- [x] `npm run check:externals` がローカルでパス
- [x] `npm run smoke` がローカルでパス
- [x] `npm run verify` (build + check:externals + smoke) がローカルでパス
- [ ] CI が通ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ビルド成果物の主要な公開エクスポートを確認するスモークテストを追加しました。
  * 外部依存関係の宣言漏れを検出するチェックを追加しました。
  * ビルド処理でこれらの検証を自動実行するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->