### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/maps-core",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/npm/index.cjs",
   "module": "dist/npm/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,8 @@
 /**
  * `@geolonia/maps-core` のバージョン文字列です。
  * index.ts から `coreVersion` という名前で公開されます。
+ *
+ * 値はビルド時に package.json の version から自動注入されます。
  */
-export const VERSION = "0.4.3";
+declare const __PACKAGE_VERSION__: string;
+export const VERSION: string = __PACKAGE_VERSION__;

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
  * `@geolonia/maps-core` のバージョン文字列です。
  * index.ts から `coreVersion` という名前で公開されます。
  */
-export const VERSION = "0.1.0";
+export const VERSION = "0.4.3";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "tsup";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -8,5 +11,6 @@ export default defineConfig({
   outDir: "dist/npm",
   define: {
     global: "globalThis",
+    __PACKAGE_VERSION__: JSON.stringify(pkg.version),
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vite";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
 
 export default defineConfig({
   root: "example",
@@ -7,5 +10,6 @@ export default defineConfig({
   },
   define: {
     global: "globalThis",
+    __PACKAGE_VERSION__: JSON.stringify(pkg.version),
   },
 });

--- a/vite.umd.config.ts
+++ b/vite.umd.config.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vite";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
 
 export default defineConfig({
   build: {
@@ -14,5 +17,6 @@ export default defineConfig({
   },
   define: {
     global: "globalThis",
+    __PACKAGE_VERSION__: JSON.stringify(pkg.version),
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 
+const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
+
 export default defineConfig({
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(pkg.version),
+  },
   test: {
     include: ["test/**/*.test.ts"],
   },


### PR DESCRIPTION
## Summary
- バージョンを 0.4.3 に bump

## 0.4.2 からの変更点
- #94 fix: maplibre-gl の named import 問題を修正
- #95 ci: native-ESM smoke test と external-import guard を追加
- #96 docs: TypeDoc API リファレンス生成を追加
- #97 docs: 公開 API の TSDoc を日本語化・充実

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * `@geolonia/maps-core` のバージョンを **0.4.3** に更新しました。
* **Build / Release**
  * ビルド時にパッケージのバージョン文字列を埋め込む仕組みを追加し、公開されるバージョン情報を最新に反映しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->