### PR TITLE
fix(keyring): stage の既定値を "dev" から "v1"（本番）に変更する, bumpt up v0.5.0

### DIFF
--- a/e2e/default-stage.spec.ts
+++ b/e2e/default-stage.spec.ts
@@ -41,19 +41,37 @@ test.describe("default stage (no stage option)", () => {
   });
 
   test("does not rewrite tile hosts to tileserver-dev", async ({ page }) => {
+    // dev ホストが 0 件であることだけを見ると、そもそもタイルサーバへ
+    // 一度もリクエストしていない場合にも通ってしまう。本番ホストへの
+    // リクエストが実際に起きたことを合わせて確認する。
+    const prodHosts: string[] = [];
     const devHosts: string[] = [];
     page.on("request", (req) => {
       const host = new URL(req.url()).host;
-      if (host.endsWith("-dev.geolonia.com") && host.startsWith("tileserver")) {
-        devHosts.push(host);
+      if (host === "tileserver.geolonia.com") prodHosts.push(req.url());
+      if (host === "tileserver-dev.geolonia.com") devHosts.push(req.url());
+    });
+
+    // タイルサーバの応答そのものを見る。collectConsoleErrors は
+    // "Failed to load resource" を除外するので、リソース取得の失敗を
+    // コンソール経由では検知できない。
+    const failed: string[] = [];
+    page.on("response", (res) => {
+      const host = new URL(res.url()).host;
+      if (host.startsWith("tileserver") && res.status() >= 400) {
+        failed.push(`${res.status()} ${res.url()}`);
       }
     });
 
     const errors = collectConsoleErrors(page);
     await page.goto("/geolonia-style.html");
     await waitForMapLoad(page);
+    await expect
+      .poll(() => prodHosts.length, { timeout: 10_000 })
+      .toBeGreaterThan(0);
 
     expect(devHosts).toHaveLength(0);
+    expect(failed).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
 });

--- a/e2e/default-stage.spec.ts
+++ b/e2e/default-stage.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import { collectConsoleErrors, waitForMapLoad } from "./helper";
+
+// stage を指定しなかったときに本番を向くことを検証する e2e。
+//
+// keyring の既定は "v1"（src/lib/keyring.ts の DEFAULT_STAGE）。かつては "dev"
+// だったため、stage を渡し忘れた npm 利用者が黙って dev 環境を叩いていた。
+// dev を明示したときの挙動は dev-environment.spec.ts が担保しているので、
+// ここでは「指定しない場合」だけを見る。
+//
+// example/geolonia-style.ts は ?stage= がある時だけ options.stage を設定するので、
+// クエリなしでアクセスすれば既定値の経路を通る。
+test.describe("default stage (no stage option)", () => {
+  test.beforeEach(async ({ page }) => {
+    // glyph は dev サーバへ寄せる（本番の CORS 未対応回避。他の spec と同様）。
+    await page.route("**/glyphs.geolonia.com/**", (route) => {
+      const url = route
+        .request()
+        .url()
+        .replace("glyphs.geolonia.com", "glyphs-dev.geolonia.com");
+      route.continue({ url });
+    });
+  });
+
+  test("requests production sprites, not dev", async ({ page }) => {
+    const devSprites: string[] = [];
+    const prodSprites: string[] = [];
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes("api.geolonia.com/dev/sprites/")) devSprites.push(url);
+      if (url.includes("api.geolonia.com/v1/sprites/")) prodSprites.push(url);
+    });
+
+    await page.goto("/geolonia-style.html");
+    await waitForMapLoad(page);
+    await expect
+      .poll(() => prodSprites.length, { timeout: 10_000 })
+      .toBeGreaterThan(0);
+
+    expect(devSprites).toHaveLength(0);
+  });
+
+  test("does not rewrite tile hosts to tileserver-dev", async ({ page }) => {
+    const devHosts: string[] = [];
+    page.on("request", (req) => {
+      const host = new URL(req.url()).host;
+      if (host.endsWith("-dev.geolonia.com") && host.startsWith("tileserver")) {
+        devHosts.push(host);
+      }
+    });
+
+    const errors = collectConsoleErrors(page);
+    await page.goto("/geolonia-style.html");
+    await waitForMapLoad(page);
+
+    expect(devHosts).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/maps-core",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "type": "module",
   "main": "dist/npm/index.cjs",
   "module": "dist/npm/index.js",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -5,7 +5,7 @@ const m = await import(new URL("../dist/npm/index.js", import.meta.url));
 
 const requiredClasses = ["GeoloniaMap", "GeoloniaMarker", "CustomAttributionControl", "GeoloniaControl", "SimpleStyle", "SimpleStyleVector"];
 const requiredFunctions = ["getLang", "getStyle", "isGeoloniaTilesHost"];
-const requiredValues = ["keyring", "coreVersion"];
+const requiredValues = ["keyring", "coreVersion", "DEFAULT_STAGE"];
 
 const missing = [];
 for (const name of requiredClasses) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export { GeoloniaControl } from "./lib/controls/geolonia-logo";
 export { default as GeoloniaMap } from "./lib/geolonia-map";
 export { default as GeoloniaMarker } from "./lib/geolonia-marker";
 // Configuration
-export { keyring } from "./lib/keyring";
+export { DEFAULT_STAGE, keyring } from "./lib/keyring";
 export { SimpleStyle } from "./lib/simplestyle";
 export { default as SimpleStyleVector } from "./lib/simplestyle-vector";
 

--- a/src/lib/keyring.ts
+++ b/src/lib/keyring.ts
@@ -1,4 +1,20 @@
 /**
+ * ステージの既定値。
+ *
+ * かつては `"dev"` だった。stage が `"dev"` のとき SDK は
+ * `tileserver.geolonia.com` を `tileserver-dev.geolonia.com` へ書き換え、
+ * API も `https://api.geolonia.com/dev` を向く（`GeoloniaMap` を参照）。
+ *
+ * CDN 版の embed はスクリプトタグから stage を読んで設定するが、npm 経由で
+ * SDK を直接使う場合はその材料がない。既定が `"dev"` だと、stage を渡し忘れた
+ * 利用者が黙って dev 環境を叩いてしまう。既定は本番であるべきなので `"v1"` にする。
+ *
+ * dev を使いたい場合は {@link Keyring.setStage} か `GeoloniaMap` の
+ * `stage` オプションで明示的に指定する。
+ */
+const DEFAULT_STAGE = "v1";
+
+/**
  * API キー、ステージ、現在のスタイルが Geolonia スタイルかどうかを保持するクラスです。
  *
  * これらの値は SDK 全体で共有され、地図タイルやスタイルの取得時に参照されます。
@@ -15,7 +31,7 @@
  */
 class Keyring {
   #apiKey = "";
-  #stage = "dev";
+  #stage = DEFAULT_STAGE;
   #isGeoloniaStyle = true;
 
   /**
@@ -32,7 +48,7 @@ class Keyring {
   /**
    * 現在設定されているステージを返します。
    *
-   * 初期値は `"dev"` です。
+   * 初期値は `"v1"`（本番）です。{@link DEFAULT_STAGE} を参照してください。
    *
    * @returns ステージを表す文字列を返します。
    */
@@ -79,11 +95,11 @@ class Keyring {
   /**
    * API キー、ステージ、Geolonia スタイル判定をすべて初期状態に戻します。
    *
-   * API キーは空文字列、ステージは `"dev"`、Geolonia スタイル判定は `true` にリセットされます。
+   * API キーは空文字列、ステージは `"v1"`、Geolonia スタイル判定は `true` にリセットされます。
    */
   reset() {
     this.#apiKey = "";
-    this.#stage = "dev";
+    this.#stage = DEFAULT_STAGE;
     this.#isGeoloniaStyle = true;
   }
 

--- a/src/lib/keyring.ts
+++ b/src/lib/keyring.ts
@@ -1,18 +1,31 @@
 /**
- * ステージの既定値。
+ * ステージの既定値です。本番環境を表す `"v1"` です。
  *
- * かつては `"dev"` だった。stage が `"dev"` のとき SDK は
- * `tileserver.geolonia.com` を `tileserver-dev.geolonia.com` へ書き換え、
- * API も `https://api.geolonia.com/dev` を向く（`GeoloniaMap` を参照）。
+ * ステージは、SDK がタイルや API をどの環境から取得するかを決める値です。
+ * `stage` を指定しなかった場合は、この値が使われます。
  *
- * CDN 版の embed はスクリプトタグから stage を読んで設定するが、npm 経由で
- * SDK を直接使う場合はその材料がない。既定が `"dev"` だと、stage を渡し忘れた
- * 利用者が黙って dev 環境を叩いてしまう。既定は本番であるべきなので `"v1"` にする。
+ * - `"v1"`（既定）: 本番環境。`tileserver.geolonia.com` と `https://api.geolonia.com/v1` を使用します。
+ * - `"dev"`: 開発環境。`tileserver-dev.geolonia.com` と `https://api.geolonia.com/dev` を使用します。
  *
- * dev を使いたい場合は {@link Keyring.setStage} か `GeoloniaMap` の
- * `stage` オプションで明示的に指定する。
+ * 通常は指定する必要がありません。開発環境を使う場合のみ、`GeoloniaMap` の
+ * `stage` オプションか {@link Keyring.setStage} で明示的に切り替えてください。
+ *
+ * `@geolonia/maps-react` や `@geolonia/maps-suite` のようなラッパーが、
+ * 自身の既定として参照することを想定して公開しています。値をハードコードせず
+ * この定数を使うことで、SDK 全体で既定のステージが揃います。
+ *
+ * @example
+ * ```typescript
+ * import { DEFAULT_STAGE, GeoloniaMap } from "@geolonia/maps-core";
+ *
+ * new GeoloniaMap({
+ *   container: "#map",
+ *   apiKey: "YOUR-API-KEY",
+ *   stage: DEFAULT_STAGE,
+ * });
+ * ```
  */
-const DEFAULT_STAGE = "v1";
+export const DEFAULT_STAGE = "v1";
 
 /**
  * API キー、ステージ、現在のスタイルが Geolonia スタイルかどうかを保持するクラスです。
@@ -48,7 +61,7 @@ class Keyring {
   /**
    * 現在設定されているステージを返します。
    *
-   * 初期値は `"v1"`（本番）です。{@link DEFAULT_STAGE} を参照してください。
+   * 初期値は {@link DEFAULT_STAGE}（`"v1"`）です。
    *
    * @returns ステージを表す文字列を返します。
    */
@@ -95,7 +108,7 @@ class Keyring {
   /**
    * API キー、ステージ、Geolonia スタイル判定をすべて初期状態に戻します。
    *
-   * API キーは空文字列、ステージは `"v1"`、Geolonia スタイル判定は `true` にリセットされます。
+   * API キーは空文字列、ステージは {@link DEFAULT_STAGE}、Geolonia スタイル判定は `true` にリセットされます。
    */
   reset() {
     this.#apiKey = "";

--- a/test/keyring.test.ts
+++ b/test/keyring.test.ts
@@ -8,8 +8,14 @@ describe("keyring", () => {
 
   it("should have default values", () => {
     expect(keyring.apiKey).toBe("");
-    expect(keyring.stage).toBe("dev");
+    // 既定は本番。dev だと stage を渡し忘れた npm 利用者が
+    // tileserver-dev / api.geolonia.com/dev を黙って叩いてしまう。
+    expect(keyring.stage).toBe("v1");
     expect(keyring.isGeoloniaStyle).toBe(true);
+  });
+
+  it("should not default to the dev stage", () => {
+    expect(keyring.stage).not.toBe("dev");
   });
 
   it("should set and get apiKey", () => {
@@ -33,7 +39,7 @@ describe("keyring", () => {
     keyring.isGeoloniaStyle = false;
     keyring.reset();
     expect(keyring.apiKey).toBe("");
-    expect(keyring.stage).toBe("dev");
+    expect(keyring.stage).toBe("v1");
     expect(keyring.isGeoloniaStyle).toBe(true);
   });
 

--- a/test/keyring.test.ts
+++ b/test/keyring.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { keyring } from "../src/lib/keyring";
+import { DEFAULT_STAGE, keyring } from "../src/lib/keyring";
 
 describe("keyring", () => {
   beforeEach(() => {
@@ -11,7 +11,7 @@ describe("keyring", () => {
   // 初期値そのものは下の "module defaults" で確認する。
   it("should have default values after reset", () => {
     expect(keyring.apiKey).toBe("");
-    expect(keyring.stage).toBe("v1");
+    expect(keyring.stage).toBe(DEFAULT_STAGE);
     expect(keyring.isGeoloniaStyle).toBe(true);
   });
 
@@ -36,7 +36,7 @@ describe("keyring", () => {
     keyring.isGeoloniaStyle = false;
     keyring.reset();
     expect(keyring.apiKey).toBe("");
-    expect(keyring.stage).toBe("v1");
+    expect(keyring.stage).toBe(DEFAULT_STAGE);
     expect(keyring.isGeoloniaStyle).toBe(true);
   });
 
@@ -91,12 +91,19 @@ describe("keyring", () => {
 // シングルトンを reset() せずに読み込み直し、コンストラクタの初期値を見る。
 // Keyring クラスは export していないので、モジュールを再評価して確認する。
 describe("keyring module defaults", () => {
-  it("defaults stage to the production stage without any reset", async () => {
+  it("exposes the production stage as DEFAULT_STAGE", () => {
+    // ラッパー（maps-react / maps-suite）がこの値を参照するので、
+    // 実際の文字列そのものを固定しておく。
+    expect(DEFAULT_STAGE).toBe("v1");
+  });
+
+  it("defaults stage to DEFAULT_STAGE without any reset", async () => {
     vi.resetModules();
     const fresh = await import("../src/lib/keyring");
     // 既定が "dev" だと、stage を渡し忘れた npm 利用者が
     // tileserver-dev / api.geolonia.com/dev を黙って叩いてしまう。
-    expect(fresh.keyring.stage).toBe("v1");
+    expect(fresh.keyring.stage).toBe(fresh.DEFAULT_STAGE);
+    expect(fresh.DEFAULT_STAGE).toBe("v1");
     expect(fresh.keyring.apiKey).toBe("");
     expect(fresh.keyring.isGeoloniaStyle).toBe(true);
   });

--- a/test/keyring.test.ts
+++ b/test/keyring.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { keyring } from "../src/lib/keyring";
 
 describe("keyring", () => {
@@ -6,16 +6,13 @@ describe("keyring", () => {
     keyring.reset();
   });
 
-  it("should have default values", () => {
+  // beforeEach で reset() を呼んでいるので、これが見ているのは
+  // コンストラクタの初期値ではなく reset() 後の状態。
+  // 初期値そのものは下の "module defaults" で確認する。
+  it("should have default values after reset", () => {
     expect(keyring.apiKey).toBe("");
-    // 既定は本番。dev だと stage を渡し忘れた npm 利用者が
-    // tileserver-dev / api.geolonia.com/dev を黙って叩いてしまう。
     expect(keyring.stage).toBe("v1");
     expect(keyring.isGeoloniaStyle).toBe(true);
-  });
-
-  it("should not default to the dev stage", () => {
-    expect(keyring.stage).not.toBe("dev");
   });
 
   it("should set and get apiKey", () => {
@@ -88,5 +85,19 @@ describe("keyring", () => {
         keyring.isGeoloniaStyleCheck("pmtiles://example.com/tiles.pmtiles"),
       ).toBe(false);
     });
+  });
+});
+
+// シングルトンを reset() せずに読み込み直し、コンストラクタの初期値を見る。
+// Keyring クラスは export していないので、モジュールを再評価して確認する。
+describe("keyring module defaults", () => {
+  it("defaults stage to the production stage without any reset", async () => {
+    vi.resetModules();
+    const fresh = await import("../src/lib/keyring");
+    // 既定が "dev" だと、stage を渡し忘れた npm 利用者が
+    // tileserver-dev / api.geolonia.com/dev を黙って叩いてしまう。
+    expect(fresh.keyring.stage).toBe("v1");
+    expect(fresh.keyring.apiKey).toBe("");
+    expect(fresh.keyring.isGeoloniaStyle).toBe(true);
   });
 });


### PR DESCRIPTION
geolonia/maps-react#70 で niryuu さんからいただいた「maps-core 側の修正の方が妥当では」という指摘への対応です。根本原因はこちらにあります。多層防御として、ラッパー側（maps-react#70）と両方に入れる方針です。

## 何が起きていたか

`Keyring` の `#stage` は初期値が `"dev"` でした。stage が `"dev"` のとき SDK は `tileserver.geolonia.com` を `tileserver-dev.geolonia.com` へ書き換え、API も `https://api.geolonia.com/dev` を向きます。

```ts
// src/lib/keyring.ts
#stage = "dev";

// src/lib/geolonia-map.ts
if (options.stage) { keyring.setStage(options.stage); }   // 未指定なら初期値のまま
const stage = options.stage || keyring.stage;
const apiUrl = `https://api.geolonia.com/${stage}`;
...
if (stage === "dev" && hostname === "tileserver.geolonia.com") {
  hostname = "tileserver-dev.geolonia.com";
}
```

CDN 版の embed はスクリプトタグから stage を読んで `setStage` するので影響を受けませんが、npm 経由で SDK を使う場合はその材料がありません。`GeoloniaMap` は `options.stage` が falsy なら `setStage` を呼ばないため、渡し忘れるとシングルトンの初期値がそのまま効き、**黙って dev 環境を叩く**ことになります。

「材料が無いときの既定が dev」という設計自体を改めます。

## 変更

```diff
-  #stage = "dev";
+  #stage = DEFAULT_STAGE;   // "v1"
```

`reset()` も同じ既定に揃えました。dev を使いたい場合は `setStage` か `GeoloniaMap` の `stage` オプションで明示します。

## 影響の確認

| 利用者 | stage の決まり方 | 影響 |
| --- | --- | --- |
| embed | `parseScriptTagApiKey` が返した値を `render` で `setStage`。値はビルド時の `MAP_PLATFORM_STAGE` 由来 | なし |
| maps-suite | `GeoloniaMap` に `stage: "v1"` を渡している | なし |
| maps-react | 既定なし。今回の不具合を踏んでいた（geolonia/maps-react#70） | 解消 |
| 本リポジトリの e2e | `?stage=dev` / `?stage=v1` と明示指定 | なし |

意図的に dev を検証している `dev-environment.spec.ts` と `authentication.spec.ts` はクエリで明示しているので、既定値変更の影響を受けません。**e2e は全 66 件通過**しています。

## テスト

**unit**: 既定値の期待を `"v1"` に更新し、`"dev"` にならないことの検査を追加しました（143 passed）。

**e2e**: `e2e/default-stage.spec.ts` を追加しました。`example/geolonia-style.ts` は `?stage=` があるときだけ `options.stage` を設定するので、クエリなしでアクセスすれば既定値の経路を通ります。

| 内容 |
| --- |
| stage 未指定のとき sprite が `api.geolonia.com/v1` を向き、dev を叩かないこと |
| stage 未指定のとき `tileserver-dev` へ書き換えられないこと |

**既定値を `"dev"` に戻すと両方落ちることを確認済み**です。dev を明示したときの挙動は `dev-environment.spec.ts` が引き続き担保します。

## バージョン

`0.5.0` にしています。不具合修正ではありますが、既定のリクエスト先という観測可能な挙動が変わるため、パッチではなくマイナーが妥当と判断しました。

## 影響範囲の参考

docs.geolonia.com でドキュメントのコード例を実行可能にしたところ、50本のデモのうち 17本が dev 環境にリクエストしていました。17本すべてが maps-react の例で、うち1本は dev のタイルが 500 を返すため真っ白でした。

## maps-react#70 との関係

この PR が入っても maps-react 側の既定は残す想定です。maps-react の依存は `^0.4.3` なので、既存の lockfile を持つ利用者は 0.4.3 のままになり、この修正が届きません。ラッパー側にも既定があれば、どの maps-core に解決されても本番を向きます。maps-suite が既に `stage: "v1"` を渡しているのと揃える意味もあります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ステージ未指定時の既定値を `v1` に変更しました。
* **バグ修正**
  * ステージのリセット後も `v1` が適用されるよう改善しました。
* **テスト**
  * 既定ステージで正しいAPIが利用されることや、不要な開発環境へのアクセス・コンソールエラーがないことを確認するE2Eテストを追加しました。
* **その他**
  * バージョンを `0.5.0` に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->