### PR TITLE
fix(attribution): maplibre-gl 5.11.0 以降で帰属表示が空になる問題を修正

### DIFF
--- a/e2e/geojson.spec.ts
+++ b/e2e/geojson.spec.ts
@@ -30,14 +30,18 @@ test.describe("GeoJSON / SimpleStyle", () => {
     await waitForMapLoad(page);
 
     expect(await hasSource(page, "geolonia-simple-style-points")).toBe(true);
-    const featureCount = await page.evaluate(() => {
+    // GeoJSONSource の内部プロパティ `_data` は maplibre-gl のバージョンで形が変わるため、
+    // 公開 API の `getData()` を使う。
+    const featureCount = await page.evaluate(async () => {
       const map = (window as unknown as Record<string, unknown>).map as {
         getSource: (
           id: string,
-        ) => { _data?: { features?: unknown[] } } | undefined;
+        ) => { getData?: () => Promise<{ features?: unknown[] }> } | undefined;
       };
       const src = map.getSource("geolonia-simple-style-points");
-      return src?._data?.features?.length ?? 0;
+      if (!src?.getData) return 0;
+      const data = await src.getData();
+      return data?.features?.length ?? 0;
     });
     expect(featureCount).toBe(3);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/tinycolor2": "^1.4.6",
         "@vitest/coverage-v8": "^4.1.2",
         "jsdom": "^29.0.1",
-        "maplibre-gl": "5.7.0",
+        "maplibre-gl": "5.24.0",
         "tsup": "^8",
         "typedoc": "^0.28.20",
         "typedoc-plugin-markdown": "^4.12.0",
@@ -1006,25 +1006,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mapbox/geojson-rewind": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
-      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-      "license": "ISC",
-      "dependencies": {
-        "get-stream": "^6.0.1",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "geojson-rewind": "geojson-rewind"
-      }
-    },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -1072,23 +1060,37 @@
       "license": "ISC"
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.3.0.tgz",
-      "integrity": "sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "quickselect": "^3.0.0",
-        "rw": "^1.3.3",
         "tinyqueue": "^3.0.0"
       },
       "bin": {
         "gl-style-format": "dist/gl-style-format.mjs",
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
+      "integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
       }
     },
     "node_modules/@maplibre/vt-pbf": {
@@ -1920,15 +1922,6 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
-    "node_modules/@types/geojson-vt": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
-      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/hast": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
@@ -2579,24 +2572,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/geojson-vt": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
-      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-      "license": "ISC"
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
@@ -2772,9 +2747,9 @@
       "license": "MIT"
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "license": "ISC"
     },
     "node_modules/launder": {
@@ -3153,32 +3128,29 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.0.tgz",
-      "integrity": "sha512-Hs+Y0qbR1iZo+07WuSbYUCOOUK45pPRzA3+7Pes8Y9jCcAqZendIMcVP6O99CWD1V/znh3qHgaZOAi3jlVxwcg==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.0.7",
+        "@mapbox/tiny-sdf": "^2.1.0",
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^23.3.0",
-        "@maplibre/vt-pbf": "^4.0.3",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
         "@types/geojson": "^7946.0.16",
-        "@types/geojson-vt": "3.2.5",
-        "@types/supercluster": "^7.1.3",
         "earcut": "^3.0.2",
-        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.4",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
         "pbf": "^4.0.1",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
-        "supercluster": "^8.0.1",
         "tinyqueue": "^3.0.0"
       },
       "engines": {
@@ -3187,6 +3159,15 @@
       },
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
       }
     },
     "node_modules/markdown-it": {
@@ -3709,12 +3690,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/sanitize-html": {
       "version": "2.17.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/tinycolor2": "^1.4.6",
     "@vitest/coverage-v8": "^4.1.2",
     "jsdom": "^29.0.1",
-    "maplibre-gl": "5.7.0",
+    "maplibre-gl": "5.24.0",
     "tsup": "^8",
     "typedoc": "^0.28.20",
     "typedoc-plugin-markdown": "^4.12.0",

--- a/src/lib/controls/attribution.ts
+++ b/src/lib/controls/attribution.ts
@@ -34,23 +34,33 @@ export interface CustomAttributionControlOptions {
 }
 
 /**
+ * 帰属表示の収集に必要な、ソースごとのタイル管理オブジェクトの最小形です。
+ * maplibre-gl の `SourceCache` / `TileManager` のいずれにも当てはまります。
+ */
+interface AttributionSourceEntry {
+  used: boolean;
+  usedForTerrain: boolean;
+  getSource(): { attribution?: string };
+}
+
+/**
  * MapLibre Map with internal properties used by this control.
  * These are internal APIs not in the public MapLibre type.
  * We use a type alias (not interface extends) to avoid conflicts
  * with MapLibre's `style` property type.
+ *
+ * `sourceCaches` は maplibre-gl 5.11.0 で `tileManagers` に改名されました。
+ * どちらの版でも動くように、両方を optional として宣言します。
+ * optional にしておくことで、参照側でフォールバックを省くと型エラーになります。
  */
 type MapInternal = MaplibreMap & {
   _getUIString(key: string): string;
   style: MaplibreMap["style"] & {
     stylesheet?: { owner: string; id: string };
-    sourceCaches: Record<
-      string,
-      {
-        used: boolean;
-        usedForTerrain: boolean;
-        getSource(): { attribution?: string };
-      }
-    >;
+    /** maplibre-gl 5.11.0 以降のプロパティ名です。 */
+    tileManagers?: Record<string, AttributionSourceEntry>;
+    /** maplibre-gl 5.11.0 未満のプロパティ名です。 */
+    sourceCaches?: Record<string, AttributionSourceEntry>;
   };
 };
 
@@ -365,11 +375,14 @@ class CustomAttributionControl implements IControl {
       }
     }
 
-    const sourceCaches = this._map.style.sourceCaches;
-    for (const id in sourceCaches) {
-      const sourceCache = sourceCaches[id];
-      if (sourceCache.used || sourceCache.usedForTerrain) {
-        const source = sourceCache.getSource();
+    // maplibre-gl 5.11.0 で `sourceCaches` が `tileManagers` に改名されたため、
+    // どちらの版でも帰属表示を収集できるようにフォールバックします。
+    const tileManagers =
+      this._map.style.tileManagers ?? this._map.style.sourceCaches ?? {};
+    for (const id in tileManagers) {
+      const tileManager = tileManagers[id];
+      if (tileManager.used || tileManager.usedForTerrain) {
+        const source = tileManager.getSource();
         if (
           source.attribution &&
           attributions.indexOf(source.attribution) < 0

--- a/test/attribution.test.ts
+++ b/test/attribution.test.ts
@@ -35,6 +35,13 @@ afterAll(() => {
 });
 
 /**
+ * maplibre-gl は 5.11.0 で `style.sourceCaches` を `style.tileManagers` に改名した。
+ * どちらの版でも帰属表示が壊れないことを確かめるため、両方の名前でテストする。
+ */
+const SOURCE_CONTAINER_KEYS = ["tileManagers", "sourceCaches"] as const;
+type SourceContainerKey = (typeof SOURCE_CONTAINER_KEYS)[number];
+
+/**
  * Extend MockMap with internal properties required by CustomAttributionControl.
  */
 function createAttributionMap(
@@ -44,6 +51,11 @@ function createAttributionMap(
       string,
       { used: boolean; usedForTerrain: boolean; attribution?: string }
     >;
+    /**
+     * ソース一覧を保持する `style` のプロパティ名。
+     * 省略した場合は maplibre-gl 5.11.0 以降の `tileManagers` を使う。
+     */
+    sourceContainerKey?: SourceContainerKey;
   } = {},
 ) {
   const map = new MockMap();
@@ -58,7 +70,7 @@ function createAttributionMap(
   (map as unknown as Record<string, unknown>)._getUIString = (key: string) =>
     `ui:${key}`;
 
-  // Internal style property with sourceCaches
+  // Internal style property holding the per-source tile managers
   const caches: Record<string, unknown> = {};
   for (const [id, sc] of Object.entries(opts.sourceCaches ?? {})) {
     caches[id] = {
@@ -68,7 +80,7 @@ function createAttributionMap(
     };
   }
   (map as unknown as Record<string, unknown>).style = {
-    sourceCaches: caches,
+    [opts.sourceContainerKey ?? "tileManagers"]: caches,
   };
 
   return map;
@@ -231,30 +243,86 @@ describe("CustomAttributionControl", () => {
       expect(inner?.innerHTML).toBe("© A");
     });
 
-    it("should collect attributions from source caches", () => {
-      const map = createAttributionMap({
-        sourceCaches: {
+    // maplibre-gl 5.11.0 の `sourceCaches` → `tileManagers` 改名で
+    // 帰属表示が空になった不具合の回帰テスト。
+    for (const key of SOURCE_CONTAINER_KEYS) {
+      describe(`with style.${key}`, () => {
+        const sourceCaches = {
           src1: { used: true, usedForTerrain: false, attribution: "© Source1" },
-          src2: {
-            used: false,
-            usedForTerrain: true,
-            attribution: "© Source2",
-          },
-          src3: {
-            used: false,
-            usedForTerrain: false,
-            attribution: "© Unused",
-          },
-        },
+          src2: { used: false, usedForTerrain: true, attribution: "© Source2" },
+          src3: { used: false, usedForTerrain: false, attribution: "© Unused" },
+        };
+
+        it("should collect attributions from used sources", () => {
+          const map = createAttributionMap({
+            sourceContainerKey: key,
+            sourceCaches,
+          });
+          const ctrl = new CustomAttributionControl();
+          const container = ctrl.onAdd(map as never);
+          const inner = container.shadowRoot?.querySelector(
+            ".maplibregl-ctrl-attrib-inner",
+          );
+          expect(inner?.innerHTML).toContain("© Source1");
+          expect(inner?.innerHTML).toContain("© Source2");
+          expect(inner?.innerHTML).not.toContain("© Unused");
+        });
+
+        it("should render non-empty attribution text", () => {
+          const map = createAttributionMap({
+            sourceContainerKey: key,
+            sourceCaches,
+          });
+          const ctrl = new CustomAttributionControl();
+          const container = ctrl.onAdd(map as never);
+          const inner = container.shadowRoot?.querySelector(
+            ".maplibregl-ctrl-attrib-inner",
+          );
+          expect(inner?.textContent?.trim().length).toBeGreaterThan(0);
+        });
+
+        it("should not mark the control as empty", () => {
+          const map = createAttributionMap({
+            sourceContainerKey: key,
+            sourceCaches,
+          });
+          const ctrl = new CustomAttributionControl();
+          const container = ctrl.onAdd(map as never);
+          const details = container.shadowRoot?.querySelector("details");
+          expect(details?.classList.contains("maplibregl-attrib-empty")).toBe(
+            false,
+          );
+        });
+
+        it("should combine custom attribution with source attributions", () => {
+          const map = createAttributionMap({
+            sourceContainerKey: key,
+            sourceCaches,
+          });
+          const ctrl = new CustomAttributionControl({
+            customAttribution: "© Geolonia",
+          });
+          const container = ctrl.onAdd(map as never);
+          const inner = container.shadowRoot?.querySelector(
+            ".maplibregl-ctrl-attrib-inner",
+          );
+          expect(inner?.innerHTML).toContain("© Geolonia");
+          expect(inner?.innerHTML).toContain("© Source1");
+        });
       });
-      const ctrl = new CustomAttributionControl();
+    }
+
+    it("should tolerate a style without any source container", () => {
+      const map = createAttributionMap();
+      (map as unknown as Record<string, unknown>).style = {};
+      const ctrl = new CustomAttributionControl({
+        customAttribution: "© Geolonia",
+      });
       const container = ctrl.onAdd(map as never);
       const inner = container.shadowRoot?.querySelector(
         ".maplibregl-ctrl-attrib-inner",
       );
-      expect(inner?.innerHTML).toContain("© Source1");
-      expect(inner?.innerHTML).toContain("© Source2");
-      expect(inner?.innerHTML).not.toContain("© Unused");
+      expect(inner?.innerHTML).toBe("© Geolonia");
     });
 
     it("should add maplibregl-attrib-empty class when no attributions", () => {


### PR DESCRIPTION
Fixes #101

## 変更内容

`CustomAttributionControl._updateAttributions()` が `style.tileManagers` を参照するようにしました。maplibre-gl 5.11.0 未満では `style.sourceCaches` にフォールバックします。

`MapInternal` の型宣言では両方のプロパティを optional にしました。これによりフォールバックを省いた実装は型エラーになります。

devDependencies の maplibre-gl を 5.7.0 から 5.24.0 に更新しました。peerDependencies は `^5.0.0` のままです。

帰属表示のテキストが実際に入ることを検証するテストを、`tileManagers` と `sourceCaches` の両方について追加しました。ソース一覧を持つプロパティが存在しない場合でも `customAttribution` が表示されることも確認しています。

## 原因

maplibre-gl 5.11.0 で `style.sourceCaches` が `style.tileManagers` に改名されました。5.11.0 以降では `style.sourceCaches` が `undefined` になるため直後の `for...in` が一度も回らず、`attributions` が空のまま `maplibregl-attrib-empty` が付与されていました。

型で気付けなかった理由は2つあります。`MapInternal` が `sourceCaches` を必須プロパティとして宣言していたため、実体が無くなっても型エラーになりませんでした。また devDependencies が 5.7.0 に固定されていたため、CI では改名前の版が入り再現しませんでした。

## 検証

devDependencies を 5.24.0 に上げた状態で、修正前は e2e の `should render attribution text inside a Shadow DOM` が失敗し、修正後は通ることを確認しました。追加した unit test も、修正前は `tileManagers` 側の4件が失敗し、修正後は通ります。

- `npm test` 152 passed
- `npx playwright test e2e/attribution.spec.ts` 2 passed
- `npm run verify` build / check:externals / smoke すべて成功
- `npx tsc --noEmit` エラーなし
- `npm run lint` 指摘なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 地図の帰属表示が、新旧どちらの内部構成でも正しく表示されるようになりました。
  * 使用中のソースやカスタム帰属表示に応じた表示を改善しました。
  * 地図表示ライブラリを更新し、互換性と安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->