### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/maps-core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/maps-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "main": "dist/npm/index.cjs",
   "module": "dist/npm/index.js",


### PR DESCRIPTION
#102 で入った帰属表示の修正を配布するためのパッチリリースです。バージョンを 0.5.0 から 0.5.1 に上げるだけの変更です。

## 含まれる修正

- #102 `CustomAttributionControl` が maplibre-gl 5.11.0 以降で常に空になる問題の修正（#101）
- あわせて devDependencies の maplibre-gl が 5.7.0 から 5.24.0 に上がり、既存の e2e が回帰ガードとして機能するようになりました

## パッチ番号にした理由

`@geolonia/maps-suite@1.2.1` と `@geolonia/maps-react@0.2.0` がいずれも `@geolonia/maps-core: ^0.5.0` に依存しています。0.x の caret はマイナーを上げないため、**0.6.0 として出すと両者は修正を拾えず、それぞれのリリースが別途必要**になります。0.5.1 であればロックファイルの更新だけで反映されます。

なお `@geolonia/embed` は master が `^0.4.3`、`chore/maps-core-0.5.0` ブランチが `^0.5.0` です。前者はこのリリースでも拾えないため、embed 側でレンジの更新が必要です。

## マージ後の手順

RELEASE.md のとおり、タグを打つと CI が build / e2e / GitHub Release / npm publish まで実行します。

```
git tag v0.5.1 && git push origin v0.5.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * パッケージのバージョンを `0.5.0` から `0.5.1` に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->