### PR TITLE
fix(error): WebGL 初期化失敗時の表示を行動につながる内容にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,26 @@ const map = new GeoloniaMap({
   clusterColor: '#ff0000',
   simpleVector: 'my-tileset',   // Vector tile URL or tileset ID
   '3d': false,
+  errorMessage: undefined,      // Message shown when the map fails to initialize
 });
+```
+
+#### `errorMessage`
+
+When the map cannot be initialized (typically because WebGL is unavailable on the
+device), the container is replaced with a message telling the visitor what to try:
+restart the browser, restart the device, try another browser, update the graphics
+driver, and contact the site owner if it still fails. The message is shortened, and
+finally reduced to the headline alone, as the map container gets smaller.
+
+Pass `errorMessage` to take that over:
+
+```typescript
+// Replace the wording. The value is rendered as plain text, not as HTML.
+new GeoloniaMap({ container: '#map', errorMessage: 'Sorry, the map is unavailable.' });
+
+// Show nothing at all, e.g. when the page renders its own fallback.
+new GeoloniaMap({ container: '#map', errorMessage: false });
 ```
 
 ### `GeoloniaMarker`

--- a/e2e/webgl-error.spec.ts
+++ b/e2e/webgl-error.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * How the map fails on a device without WebGL. The fixture makes
+ * `getContext('webgl')` return null, so initialization always throws.
+ */
+test.describe("WebGL initialization failure", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/webgl-error.html");
+    await page.waitForSelector("#map-large .geolonia__error-container");
+  });
+
+  test("should show the recovery steps on a large map", async ({ page }) => {
+    const container = page.locator("#map-large");
+    await expect(
+      container.locator(".geolonia__error-message-title"),
+    ).toHaveText("地図を表示できませんでした");
+    await expect(
+      container.locator(".geolonia__error-message-lead"),
+    ).toBeVisible();
+    await expect(
+      container.locator(".geolonia__error-message-steps li"),
+    ).toHaveCount(4);
+    await expect(
+      container.locator(".geolonia__error-message-contact"),
+    ).toBeVisible();
+    await expect(
+      container.locator(".geolonia__error-message-brief"),
+    ).toBeHidden();
+  });
+
+  test("should not tell the visitor to open the developer tools", async ({
+    page,
+  }) => {
+    await expect(page.locator("#map-large")).not.toContainText("開発者ツール");
+  });
+
+  test("should fall back to the short message on a medium map", async ({
+    page,
+  }) => {
+    const container = page.locator("#map-medium");
+    await expect(
+      container.locator(".geolonia__error-message-title"),
+    ).toBeVisible();
+    await expect(
+      container.locator(".geolonia__error-message-brief"),
+    ).toBeVisible();
+    await expect(
+      container.locator(".geolonia__error-message-steps"),
+    ).toBeHidden();
+  });
+
+  test("should show the headline alone on a small map", async ({ page }) => {
+    const container = page.locator("#map-small");
+    await expect(
+      container.locator(".geolonia__error-message-title"),
+    ).toBeVisible();
+    await expect(
+      container.locator(".geolonia__error-message-brief"),
+    ).toBeHidden();
+    await expect(
+      container.locator(".geolonia__error-message-steps"),
+    ).toBeHidden();
+  });
+
+  test("should keep the message inside the map container", async ({ page }) => {
+    for (const id of ["#map-large", "#map-medium", "#map-small"]) {
+      const container = await page.locator(id).boundingBox();
+      const message = await page
+        .locator(`${id} .geolonia__error-message`)
+        .boundingBox();
+      if (!container || !message) throw new Error(`no bounding box for ${id}`);
+      expect(message.x).toBeGreaterThanOrEqual(container.x - 1);
+      expect(message.y).toBeGreaterThanOrEqual(container.y - 1);
+      expect(message.x + message.width).toBeLessThanOrEqual(
+        container.x + container.width + 1,
+      );
+      expect(message.y + message.height).toBeLessThanOrEqual(
+        container.y + container.height + 1,
+      );
+    }
+  });
+
+  test("should replace the message with errorMessage", async ({ page }) => {
+    const container = page.locator("#map-custom");
+    await expect(
+      container.locator(".geolonia__error-message-description"),
+    ).toHaveText(
+      "地図を表示できませんでした。お手数ですが 0120-000-000 までご連絡ください。",
+    );
+    await expect(
+      container.locator(".geolonia__error-message-steps"),
+    ).toHaveCount(0);
+  });
+
+  test("should render nothing when errorMessage is false", async ({ page }) => {
+    await expect(
+      page.locator("#map-off .geolonia__error-container"),
+    ).toHaveCount(0);
+  });
+
+  test("should stop the loader when initialization fails", async ({ page }) => {
+    for (const id of ["#map-large", "#map-off"]) {
+      await expect(page.locator(`${id} .loading-geolonia-map`)).toHaveCount(0);
+    }
+  });
+});

--- a/example/webgl-error.html
+++ b/example/webgl-error.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebGL error E2E</title>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+    .example { margin-bottom: 1.5rem; }
+    .map { border: 1px solid #ccc; }
+    #map-large { width: 640px; height: 400px; }
+    #map-medium { width: 360px; height: 240px; }
+    #map-small { width: 220px; height: 130px; }
+    #map-custom { width: 640px; height: 240px; }
+    #map-off { width: 640px; height: 160px; }
+  </style>
+  <script>
+    // Emulate a device without WebGL, so map initialization always fails.
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (type, ...args) {
+      if (typeof type === "string" && type.indexOf("webgl") === 0) {
+        return null;
+      }
+      return originalGetContext.call(this, type, ...args);
+    };
+  </script>
+</head>
+<body>
+  <div class="example">
+    <h2>Large map (default message, with steps)</h2>
+    <div id="map-large" class="map"></div>
+  </div>
+
+  <div class="example">
+    <h2>Medium map (default message, shortened)</h2>
+    <div id="map-medium" class="map"></div>
+  </div>
+
+  <div class="example">
+    <h2>Small map (headline only)</h2>
+    <div id="map-small" class="map"></div>
+  </div>
+
+  <div class="example">
+    <h2>Replaced message (errorMessage: string)</h2>
+    <div id="map-custom" class="map"></div>
+  </div>
+
+  <div class="example">
+    <h2>No error display (errorMessage: false)</h2>
+    <div id="map-off" class="map"></div>
+  </div>
+
+  <script type="module" src="/webgl-error.ts"></script>
+</body>
+</html>

--- a/example/webgl-error.ts
+++ b/example/webgl-error.ts
@@ -1,0 +1,36 @@
+import "maplibre-gl/dist/maplibre-gl.css";
+import "../src/assets/style.css";
+import type { GeoloniaMapOptions } from "../src/index";
+import { GeoloniaMap } from "../src/index";
+
+const base: Omit<GeoloniaMapOptions, "container"> = {
+  style: "/sample-basic-style.json",
+  center: [139.7671, 35.6812],
+  zoom: 12,
+  marker: false,
+  geoloniaControl: false,
+  gestureHandling: false,
+  navigationControl: false,
+};
+
+const cases: Array<Pick<GeoloniaMapOptions, "container" | "errorMessage">> = [
+  { container: "#map-large" },
+  { container: "#map-medium" },
+  { container: "#map-small" },
+  {
+    container: "#map-custom",
+    errorMessage:
+      "地図を表示できませんでした。お手数ですが 0120-000-000 までご連絡ください。",
+  },
+  { container: "#map-off", errorMessage: false },
+];
+
+// The constructor throws because WebGL is unavailable; that is the point of
+// this fixture. Keep going so every case renders its own error state.
+for (const options of cases) {
+  try {
+    new GeoloniaMap({ ...base, ...options });
+  } catch {
+    // expected
+  }
+}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -112,6 +112,11 @@
 }
 
 /* Style for error message */
+/*
+ * 文言は「手順を書き切った版」と「短縮版」の両方が DOM にあり、
+ * どちらを見せるかは地図コンテナの広さで切り替える。
+ * コンテナクエリ非対応のブラウザでは手順を書き切った版が出る（情報が減る側に倒さない）。
+ */
 .geolonia__error-container {
   display: flex;
   justify-content: center;
@@ -121,22 +126,82 @@
   background-color: #dedede;
   z-index: 9999;
   position: absolute;
+  container-type: size;
+  container-name: geolonia-error;
 }
 
 .geolonia__error-message {
-  max-width: 300px;
+  max-width: 360px;
+  max-height: calc(100% - 20px);
+  overflow: auto;
   background-color: #ffffff;
   margin: 10px;
   padding: 0.75rem 1.25rem;
   border-radius: 6px;
-  position: absolute;
   z-index: 99999;
   word-wrap: break-word;
   box-shadow: 0 4px 10px #0000001a;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #333333;
+}
+
+.geolonia__error-message-title {
+  margin: 0 0 0.5em;
+  font-size: 16px;
+  line-height: 1.4;
 }
 
 .geolonia__error-message-description {
-  margin: 15px 0;
+  margin: 0;
+}
+
+.geolonia__error-message-lead {
+  margin: 0 0 0.5em;
+}
+
+.geolonia__error-message-steps {
+  margin: 0 0 0.5em;
+  padding-left: 1.4em;
+}
+
+.geolonia__error-message-contact {
+  margin: 0;
+}
+
+.geolonia__error-message-brief {
+  display: none;
+  margin: 0;
+}
+
+/* 中くらいの地図：手順リストは収まらないので 1 行の短縮版に切り替える */
+@container geolonia-error ((max-width: 379px) or (max-height: 259px)) {
+  .geolonia__error-message-lead,
+  .geolonia__error-message-steps,
+  .geolonia__error-message-contact {
+    display: none;
+  }
+
+  .geolonia__error-message-brief {
+    display: block;
+  }
+}
+
+/* 小さい地図：見出しだけにする */
+@container geolonia-error ((max-width: 239px) or (max-height: 139px)) {
+  .geolonia__error-message {
+    padding: 0.5rem 0.75rem;
+    font-size: 13px;
+  }
+
+  .geolonia__error-message-title {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .geolonia__error-message-brief {
+    display: none;
+  }
 }
 
 /* CSS for Attribution */

--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -278,6 +278,7 @@ export default class GeoloniaMap extends maplibregl.Map {
       "clusterColor",
       "simpleVector",
       "3d",
+      "errorMessage",
     ] as const) {
       delete (mapOptions as Record<string, unknown>)[key];
     }
@@ -285,7 +286,10 @@ export default class GeoloniaMap extends maplibregl.Map {
     try {
       super(mapOptions);
     } catch (error) {
-      handleErrorMode(container);
+      // 初期化に失敗した以上ローディングは終わらないので、先に消す。
+      // 消さないと `errorMessage: false` のとき「読み込み中」のまま見えてしまう。
+      container.querySelector(".loading-geolonia-map")?.remove();
+      handleErrorMode(container, { message: options.errorMessage });
       throw error;
     }
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -197,17 +197,86 @@ export function handleRestrictedMode(map: {
   }
 }
 
-export function handleErrorMode(container: HTMLElement): void {
+/**
+ * 地図の初期化に失敗したときのエラー表示。
+ *
+ * 既定では「WebGL が使えない状態かもしれない」という原因と、利用者が自分で試せる
+ * 復旧手順を描画する。手順を書き切った版と 1 行の短縮版の両方を DOM に入れておき、
+ * どちらを見せるかは地図コンテナの広さに応じて CSS（コンテナクエリ）が決める。
+ *
+ * `message` に文字列を渡すとその文言に差し替える（HTML としては解釈しない）。
+ * `false` または `'off'` を渡すとエラー表示自体を行わない。
+ *
+ * @param container 地図コンテナ
+ * @param options `message` に差し替え文言、`false` / `'off'` で表示しない
+ */
+export function handleErrorMode(
+  container: HTMLElement,
+  options: { message?: string | false } = {},
+): void {
+  if (options.message === false) {
+    return;
+  }
+
+  const message = (options.message ?? "").trim();
+  if (message.toLowerCase() === "off") {
+    return;
+  }
+
   const errorContainer = document.createElement("div");
   errorContainer.classList.add("geolonia__error-container");
 
   const div = document.createElement("div");
-  const h2 = document.createElement("h2");
-  h2.textContent = "Geolonia Maps";
-  div.appendChild(h2);
   div.classList.add("geolonia__error-message");
-  div.innerHTML +=
-    '<div class="geolonia__error-message-description">地図の初期化に失敗しました。管理者にお問い合わせ下さい。</div>';
+  div.setAttribute("role", "alert");
+
+  const description = document.createElement("div");
+  description.classList.add("geolonia__error-message-description");
+
+  if (message) {
+    // 消費側が指定した文言。HTML は解釈せずテキストとして描画する。
+    description.textContent = message;
+    div.appendChild(description);
+  } else {
+    const title = document.createElement("h2");
+    title.classList.add("geolonia__error-message-title");
+    title.textContent = "地図を表示できませんでした";
+    div.appendChild(title);
+
+    const lead = document.createElement("p");
+    lead.classList.add("geolonia__error-message-lead");
+    lead.textContent =
+      "お使いの環境で地図の描画機能（WebGL）が利用できない状態になっている可能性があります。次の順にお試しください。";
+    description.appendChild(lead);
+
+    const steps = document.createElement("ol");
+    steps.classList.add("geolonia__error-message-steps");
+    for (const step of [
+      "ブラウザをすべて閉じて、開き直す",
+      "パソコンやスマートフォンを再起動する",
+      "別のブラウザで開く",
+      "パソコンの場合は、グラフィックドライバを更新する",
+    ]) {
+      const li = document.createElement("li");
+      li.textContent = step;
+      steps.appendChild(li);
+    }
+    description.appendChild(steps);
+
+    const contact = document.createElement("p");
+    contact.classList.add("geolonia__error-message-contact");
+    contact.textContent =
+      "解決しない場合は、このサイトの窓口までご連絡ください。";
+    description.appendChild(contact);
+
+    // 手順を書き切れない狭いコンテナ向け。表示の切り替えは CSS が行う。
+    const brief = document.createElement("p");
+    brief.classList.add("geolonia__error-message-brief");
+    brief.textContent = "ブラウザや端末を再起動すると解消する場合があります。";
+    description.appendChild(brief);
+
+    div.appendChild(description);
+  }
 
   errorContainer.appendChild(div);
   container.appendChild(errorContainer);

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,4 +115,11 @@ export type GeoloniaMapOptions = MapOptions & {
    * @defaultValue `false`
    */
   "3d"?: boolean;
+  /**
+   * 地図の初期化に失敗したときに表示する文言。
+   * 文字列を指定するとその文言に差し替える（HTML としては解釈しない）。
+   * `false` または `'off'` を指定するとエラー表示自体を行わない。
+   * 未指定のときは、原因と利用者が試せる復旧手順を示す既定の案内を表示する。
+   */
+  errorMessage?: string | false;
 };

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -230,12 +230,79 @@ describe("handleErrorMode", () => {
     );
     expect(errorContainer).not.toBeNull();
 
-    const h2 = errorContainer?.querySelector("h2");
-    expect(h2?.textContent).toBe("Geolonia Maps");
-
     const desc = errorContainer?.querySelector(
       ".geolonia__error-message-description",
     );
     expect(desc).not.toBeNull();
+  });
+
+  it("should tell the visitor what to try", () => {
+    const container = document.createElement("div");
+    handleErrorMode(container);
+
+    expect(
+      container.querySelector(".geolonia__error-message-title")?.textContent,
+    ).toBe("地図を表示できませんでした");
+    // Restart the browser, restart the device, try another browser,
+    // update the graphics driver.
+    expect(
+      container.querySelectorAll(".geolonia__error-message-steps li").length,
+    ).toBe(4);
+    expect(
+      container.querySelector(".geolonia__error-message-contact"),
+    ).not.toBeNull();
+  });
+
+  it("should render the short variant too, so CSS can pick one by container size", () => {
+    const container = document.createElement("div");
+    handleErrorMode(container);
+
+    expect(
+      container.querySelector(".geolonia__error-message-brief"),
+    ).not.toBeNull();
+  });
+
+  it("should not tell the visitor to open the developer tools", () => {
+    const container = document.createElement("div");
+    handleErrorMode(container);
+
+    expect(container.textContent).not.toContain("開発者ツール");
+  });
+
+  it("should replace the message with the given one", () => {
+    const container = document.createElement("div");
+    handleErrorMode(container, {
+      message: "地図を表示できませんでした。0120-000-000 までご連絡ください。",
+    });
+
+    expect(
+      container.querySelector(".geolonia__error-message-description")
+        ?.textContent,
+    ).toBe("地図を表示できませんでした。0120-000-000 までご連絡ください。");
+    expect(
+      container.querySelector(".geolonia__error-message-steps"),
+    ).toBeNull();
+  });
+
+  it("should render the given message as text, not as HTML", () => {
+    const container = document.createElement("div");
+    handleErrorMode(container, {
+      message: '<img src=x onerror="alert(1)">お問い合わせください',
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toContain(
+      '<img src=x onerror="alert(1)">お問い合わせください',
+    );
+  });
+
+  it("should render nothing when disabled", () => {
+    for (const message of ["off", "OFF", false] as const) {
+      const container = document.createElement("div");
+      handleErrorMode(container, { message });
+
+      expect(container.querySelector(".geolonia__error-container")).toBeNull();
+      expect(container.children.length).toBe(0);
+    }
   });
 });


### PR DESCRIPTION
Closes #105

embed v5 系の geolonia/embed#517 と同じ内容を maps-core に入れます。これで v6 系（maps-core 依存の embed）でも同じ表示になります。

## 何を変えたか

### 既定の文言

変更前は「地図の初期化に失敗しました。管理者にお問い合わせ下さい。」の一文のみでした。変更後は次の内容です。

- 見出し: 地図を表示できませんでした
- 原因: お使いの環境で地図の描画機能（WebGL）が利用できない状態になっている可能性があります
- 手順: ブラウザを開き直す / 端末を再起動する / 別のブラウザで開く / グラフィックドライバを更新する
- それでも直らないときの窓口案内

実際の原因は端末側の GPU の一時的な不調であることが多く、再起動で解消します。従来の文言はそこに導けていませんでした。

### 地図の広さに応じた出し分け

地図コンテナは小さいことも多いため、コンテナクエリで3段階に切り替えます。

| コンテナの広さ | 表示 |
| --- | --- |
| 380x260 以上 | 見出し + 原因 + 手順4つ + 窓口案内 |
| それ未満 | 見出し + 「ブラウザや端末を再起動すると解消する場合があります。」 |
| 240x140 未満 | 見出しのみ |

3種類とも DOM には入れておき、表示の切り替えは CSS が行います。コンテナクエリ非対応のブラウザでは手順つきの全文が出ます（情報が減る側に倒さない方針）。収まらない場合はメッセージ内でスクロールします。

### `errorMessage` オプション

```typescript
// 文言を差し替える（HTML としては解釈せず、テキストとして描画する）
new GeoloniaMap({ container: '#map', errorMessage: '地図を表示できませんでした。0120-000-000 までご連絡ください。' });

// エラー表示自体を行わない
new GeoloniaMap({ container: '#map', errorMessage: false });
```

embed 側の `data-error-message="off"` がそのまま渡ってくる場合に備えて、文字列の `'off'` も無効化として扱います。

### ローディング表示の停止

初期化に失敗してもローディングアニメーションが止まらず、`errorMessage: false` を指定すると「読み込み中のまま」に見える状態だったため、失敗時に必ず消すようにしました。

## 動作確認

- unit: 158件 green（`handleErrorMode` のケースを 1 から 7 に拡張）
- e2e: 74件 green（WebGL を無効化したフィクスチャで 8 ケース追加）
- `npm run verify`（build + check:externals + smoke）成功、biome check クリーン

`example/webgl-error.html` は `getContext('webgl')` を null にして初期化を必ず失敗させるフィクスチャです。`npm run dev` して開けば、4種類の見え方をそのまま確認できます。

## 残作業

embed v6 系（master）で `data-error-message` を `attsToOptions()` から `errorMessage` に渡す変更が別途必要です。maps-core のリリース後に対応します。